### PR TITLE
Add androidNative targets + test plugin

### DIFF
--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -3,6 +3,7 @@
  */
 
 apply plugin: 'kotlin-multiplatform'
+apply plugin: 'io.deepmedia.tools.multiplatform-testing' // androidNative test tasks
 apply from: rootProject.file("gradle/targets.gradle")
 
 ext {
@@ -95,6 +96,11 @@ if (rootProject.ext.native_targets_enabled) {
                 addTarget(presets.watchosSimulatorArm64)
                 addTarget(presets.tvosSimulatorArm64)
                 addTarget(presets.macosArm64)
+
+                addTarget(presets.androidNativeArm32)
+                addTarget(presets.androidNativeArm64)
+                addTarget(presets.androidNativeX64)
+                addTarget(presets.androidNativeX86)
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,13 @@ buildscript {
         // Future replacement for kotlin-dev, with cache redirector
         maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
         maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+        google()
     }
     
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moowork.gradle:gradle-node-plugin:$gradle_node_version"
+        classpath "io.deepmedia.tools.testing:plugin:$multiplatform_testing_version"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ mocha_version=4.1.0
 mocha_headless_chrome_version=1.8.2
 mocha_teamcity_reporter_version=2.2.2
 source_map_support_version=0.5.3
+multiplatform_testing_version=0.4.0
 
 kotlin.incremental.multiplatform=true
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
See discussion: https://github.com/Kotlin/kotlinx.atomicfu/issues/122#issuecomment-948865934

To run tests,
- set either $ANDROID_HOME or `multiplatformTesting.androidTools.sdkHome` to the Android SDK directory or, if not installed, to some directory where the plugin can download them
- run `./gradlew atomicfu:runAllAndroidNativeTests`

Testing plugin readme: https://github.com/deepmedia/multiplatform-testing/blob/main/readme.md