### PR TITLE
Replaced jcenter with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     ext.native_targets_enabled = rootProject.properties['disable_native_targets'] == null
 
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         // Future replacement for kotlin-dev, with cache redirector
         maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
@@ -56,7 +56,7 @@ allprojects {
 
     println "Using Kotlin $kotlin_version for project $it"
     repositories {
-        jcenter()
+        mavenCentral()
         // Future replacement for kotlin-dev, with cache redirector
         maven { url "https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
         maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 kotlinDslPluginOptions {


### PR DESCRIPTION
Removed old references to Bintray, that caused the resolution failure.

[Here](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_BuildPlayground_MilkyWayMargaritaBobova_atomicfu/228941213?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true) is the green build, after replacement