### PR TITLE
Update Kotlin to 1.8.0

### DIFF
--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JsProjectTest.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JsProjectTest.kt
@@ -19,6 +19,9 @@ class JsLegacyTransformationTest : BaseKotlinGradleTest("js-simple") {
         settingsGradleKts {
             resolve("projects/js-simple/settings.gradle.kts")
         }
+        gradleProperties {
+            resolve("projects/mpp-simple/gradle.properties_js_legacy")
+        }
         dir("src/main/kotlin") {}
         kotlin("IntArithmetic.kt", "main") {
             resolve("projects/js-simple/src/main/kotlin/IntArithmetic.kt")

--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/MppProjectTest.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/MppProjectTest.kt
@@ -19,6 +19,9 @@ class MppLegacyTransformationTest : BaseKotlinGradleTest("mpp-simple") {
         settingsGradleKts {
             resolve("projects/mpp-simple/settings.gradle.kts")
         }
+        gradleProperties {
+            resolve("projects/mpp-simple/gradle.properties_js_legacy")
+        }
         dir("src/commonMain/kotlin") {}
         kotlin("IntArithmetic.kt", "commonMain") {
             resolve("projects/mpp-simple/src/commonMain/kotlin/IntArithmetic.kt")

--- a/atomicfu-gradle-plugin/src/test/resources/projects/js-simple/gradle.properties_js_legacy
+++ b/atomicfu-gradle-plugin/src/test/resources/projects/js-simple/gradle.properties_js_legacy
@@ -1,0 +1,1 @@
+kotlin.js.compiler=legacy

--- a/atomicfu-gradle-plugin/src/test/resources/projects/mpp-simple/gradle.properties_js_legacy
+++ b/atomicfu-gradle-plugin/src/test/resources/projects/mpp-simple/gradle.properties_js_legacy
@@ -1,0 +1,1 @@
+kotlin.js.compiler=legacy

--- a/atomicfu-gradle-plugin/src/test/resources/projects/mpp-simple/gradle.properties_jvm
+++ b/atomicfu-gradle-plugin/src/test/resources/projects/mpp-simple/gradle.properties_jvm
@@ -1,1 +1,2 @@
 kotlinx.atomicfu.enableJvmIrTransformation=true
+kotlin.js.compiler=ir

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 version=0.18.5-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlin_version=1.7.20
+kotlin_version=1.8.0
 
 asm_version=9.3
 slf4j_version=1.8.0-alpha2


### PR DESCRIPTION
Plus explicit specification of Kotlin JS legacy backend in `atomicfu-gradle-plugin` tests, as it was deprecated in 1.8.0.