### PR TITLE
Fix compiler plugin dependency in AtomicfuGradlePlugin

### DIFF
--- a/atomicfu-gradle-plugin/build.gradle
+++ b/atomicfu-gradle-plugin/build.gradle
@@ -27,8 +27,7 @@ dependencies {
     compileOnly gradleApi()
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib'
     compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    // atomicfu compiler plugin dependency will be loaded to kotlinCompilerPluginClasspath
-    implementation "org.jetbrains.kotlin:atomicfu:$kotlin_version"
+    compileOnly "org.jetbrains.kotlin:atomicfu:$kotlin_version"
 
     testImplementation gradleTestKit()
     testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/atomicfu-gradle-plugin/build.gradle
+++ b/atomicfu-gradle-plugin/build.gradle
@@ -27,7 +27,9 @@ dependencies {
     compileOnly gradleApi()
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib'
     compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    compileOnly "org.jetbrains.kotlin:atomicfu:$kotlin_version"
+    // Atomicfu compiler plugin dependency will be loaded to kotlinCompilerPluginClasspath
+    // Atomicfu plugin will only be applied if the flag is set kotlinx.atomicfu.enableJsIrTransformation=true
+    implementation "org.jetbrains.kotlin:atomicfu:$kotlin_version"
 
     testImplementation gradleTestKit()
     testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -154,13 +154,12 @@ private fun Project.addCompilerPluginDependency() {
             if (target.isJsIrTarget()) {
                 target.compilations.forEach { kotlinCompilation ->
                     kotlinCompilation.dependencies {
-                        // Atomicfu compiler plugin dependency will be loaded to kotlinCompilerPluginClasspath
-                        // Atomicfu plugin will only be applied if the flag is set kotlinx.atomicfu.enableJsIrTransformation=true
-                        implementation("org.jetbrains.kotlin:atomicfu:${getKotlinPluginVersion()}")
                         if (getKotlinVersion().atLeast(1, 7, 10)) {
                             // since Kotlin 1.7.10 `kotlinx-atomicfu-runtime` is published and should be added directly
                             compileOnly("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
                             runtimeOnly("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
+                        } else {
+                            implementation("org.jetbrains.kotlin:atomicfu:${getKotlinPluginVersion()}")
                         }
                     }
                 }

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -151,17 +151,16 @@ private fun KotlinTarget.isJsIrTarget() = (this is KotlinJsTarget && this.irTarg
 private fun Project.addCompilerPluginDependency() {
     if (isCompilerPluginAvailable()) {
         withKotlinTargets { target ->
-            if (needsJsIrTransformation(target)) {
+            if (target.isJsIrTarget()) {
                 target.compilations.forEach { kotlinCompilation ->
                     kotlinCompilation.dependencies {
+                        // Atomicfu compiler plugin dependency will be loaded to kotlinCompilerPluginClasspath
+                        // Atomicfu plugin will only be applied if the flag is set kotlinx.atomicfu.enableJsIrTransformation=true
+                        implementation("org.jetbrains.kotlin:atomicfu:${getKotlinPluginVersion()}")
                         if (getKotlinVersion().atLeast(1, 7, 10)) {
-                            // since Kotlin 1.7.10 we can add `atomicfu-runtime` dependency directly
+                            // since Kotlin 1.7.10 `kotlinx-atomicfu-runtime` is published and should be added directly
                             compileOnly("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
                             runtimeOnly("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
-                        } else {
-                            // add atomicfu compiler plugin dependency
-                            // to provide the `atomicfu-runtime` library used during compiler plugin transformation
-                            implementation("org.jetbrains.kotlin:atomicfu:${getKotlinPluginVersion()}")
                         }
                     }
                 }


### PR DESCRIPTION
- Pass compiler plugin dependency `atomicfu` in AtomicfuGradlePlugin
- Always pass `kotlinx-atomicfu-runtime` dependency

Fixes https://youtrack.jetbrains.com/issue/KT-57235