### PR TITLE
The second fix for atomicfu-runtime dependency

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -156,8 +156,7 @@ private fun Project.addCompilerPluginDependency() {
                     kotlinCompilation.dependencies {
                         if (getKotlinVersion().atLeast(1, 7, 10)) {
                             // since Kotlin 1.7.10 `kotlinx-atomicfu-runtime` is published and should be added directly
-                            compileOnly("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
-                            runtimeOnly("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
+                            implementation("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")
                         } else {
                             implementation("org.jetbrains.kotlin:atomicfu:${getKotlinPluginVersion()}")
                         }


### PR DESCRIPTION
When we need `kotlinx-atomicfu-runtime` dependency: 
- it is used by JS IR transformer of atomicfu compiler plugin -> it should be passed to the compileClasspath
- JS IR transformer replaces atomic declarations with declarations from `kotlinx-atomicfu-runtime` -> it should be passed to the runtimeClasspath

In the last release `0.20.1` this dependency was passed as compileOnly + runtimeOnly, that caused the issue: 
`Could not find "org.jetbrains.kotlin:kotlinx-atomicfu-runtime"` in the project that depends on coroutines only. That happened because `kotlinx-atomicfu-runtime` dependency should've been in the compile classpath of that project and `compileOnly` dependency could not be found there. Hence, this dependency is fixed back to `implementation`.

This fix is not final, because now `kotlinx-atomicfu-runtime` dependency is added in any case, whether the `enableJsIrTransformation` flag is true or not. That's not completely correct and may cause double dependency warning (https://github.com/Kotlin/kotlinx-atomicfu/issues/289), though it fixes this issue (https://youtrack.jetbrains.com/issue/KT-57235), that is critical. The problem in the issue is that the project that depends on coroutines and ktor fails with `Could not find "org.jetbrains.kotlin:kotlinx-atomicfu-runtime"` -- because `ktor` klib manifest demands this dependency, though it shouldn't (the reason is under research).
