### PR TITLE
Fix build error on using KGP removed method (#297)

### DIFF
--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -345,7 +345,7 @@ task compileJavaModuleInfo(type: JavaCompile) {
 
     // Use the classpath of the compileKotlinJvm task.
     // Also ensure that the module path is used instead of classpath.
-    classpath = compileKotlinJvm.classpath
+    classpath = compileKotlinJvm.libraries
     modularity.inferModulePath.set(true)
 
     doFirst {


### PR DESCRIPTION
Related YT issue: https://youtrack.jetbrains.com/issue/KT-53748/Remove-KotlinCompile-setClasspath-getClasspath-methods

Related PR in `kotlin-community/dev`: https://github.com/Kotlin/kotlinx-atomicfu/pull/297