### PR TITLE
Duplicated class files in jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 **Atomicfu** is a multiplatform library that provides the idiomatic and effective way of using atomic operations in Kotlin.
 
 ## Table of contents
+- [Requirements](#requirements)
 - [Features](#features)
 - [Example](#example)
 - [Quickstart](#quickstart)
@@ -31,6 +32,13 @@
   - [Tracing operations](#tracing-operations)
 - [Kotlin/Native support](#kotlin-native-support)
 
+## Requirements
+
+Starting from version `0.21.0` of the library your project is required to use:
+
+* Gradle `7.0` or newer
+
+* Kotlin `1.7.0` or newer
 
 ## Features
 

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.*
 import org.gradle.api.tasks.compile.*
 import org.gradle.api.tasks.testing.*
 import org.gradle.jvm.tasks.*
+import org.gradle.util.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.plugin.*
@@ -37,15 +38,36 @@ private const val TEST_IMPLEMENTATION_CONFIGURATION = "testImplementation"
 private const val ENABLE_JS_IR_TRANSFORMATION_LEGACY = "kotlinx.atomicfu.enableIrTransformation"
 private const val ENABLE_JS_IR_TRANSFORMATION = "kotlinx.atomicfu.enableJsIrTransformation"
 private const val ENABLE_JVM_IR_TRANSFORMATION = "kotlinx.atomicfu.enableJvmIrTransformation"
+private const val MIN_SUPPORTED_GRADLE_VERSION = "7.0"
+private const val MIN_SUPPORTED_KGP_VERSION = "1.7.0"
 
 open class AtomicFUGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) = project.run {
+        checkCompatibility()
         val pluginVersion = rootProject.buildscript.configurations.findByName("classpath")
             ?.allDependencies?.find { it.name == "atomicfu-gradle-plugin" }?.version
         extensions.add(EXTENSION_NAME, AtomicFUPluginExtension(pluginVersion))
         applyAtomicfuCompilerPlugin()
         configureDependencies()
         configureTasks()
+    }
+}
+
+private fun Project.checkCompatibility() {
+    val currentGradleVersion = GradleVersion.current()
+    val kotlinVersion = getKotlinVersion()
+    val minSupportedVersion = GradleVersion.version(MIN_SUPPORTED_GRADLE_VERSION)
+    if (currentGradleVersion < minSupportedVersion) {
+        throw GradleException(
+            "The current Gradle version is not compatible with Atomicfu gradle plugin. " +
+                    "Please use Gradle $MIN_SUPPORTED_GRADLE_VERSION or newer, or the previous version of Atomicfu gradle plugin."
+        )
+    }
+    if (!kotlinVersion.atLeast(1, 7, 0)) {
+        throw GradleException(
+            "The current Kotlin gradle plugin version is not compatible with Atomicfu gradle plugin. " +
+                    "Please use Kotlin $MIN_SUPPORTED_KGP_VERSION or newer, or the previous version of Atomicfu gradle plugin."
+        )
     }
 }
 

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -242,8 +242,11 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
             ?: return@compilations // skip unknown compilations
         val classesDirs = compilation.output.classesDirs
         // make copy of original classes directory
-        val originalClassesDirs: FileCollection =
-            project.files(classesDirs.from.toTypedArray()).filter { it.exists() }
+        @Suppress("UNCHECKED_CAST")
+        val compilationTask = compilation.compileTaskProvider as TaskProvider<KotlinCompileTool>
+        val originalClassesDirs: FileCollection = project.objects.fileCollection().from(
+            compilationTask.flatMap { it.destinationDirectory }
+        )
         originalDirsByCompilation[compilation] = originalClassesDirs
         val transformedClassesDir =
             project.buildDir.resolve("classes/atomicfu/${target.name}/${compilation.name}")

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -281,9 +281,11 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
         }
         //now transformTask is responsible for compiling this source set into the classes directory
         classesDirs.setFrom(transformedClassesDir)
-        classesDirs.builtBy(transformTask)
-        (tasks.findByName(target.artifactsTaskName) as? Jar)?.apply {
-            setupJarManifest(multiRelease = config.jvmVariant.toJvmVariant() == JvmVariant.BOTH)
+        classesDirs.setBuiltBy(listOf(transformTask))
+        tasks.withType(Jar::class.java).configureEach {
+            if (name == target.artifactsTaskName) {
+                it.setupJarManifest(multiRelease = config.jvmVariant.toJvmVariant() == JvmVariant.BOTH)
+            }
         }
         // test should compile and run against original production binaries
         if (compilationType == CompilationType.TEST) {

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -313,23 +313,11 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
             val originalMainClassesDirs = project.objects.fileCollection().from(
                 mainCompilation.compileTaskProvider.flatMap { (it as KotlinCompileTool).destinationDirectory }
             )
-
-            // KGP >= 1.7.0 has breaking changes in task hierarchy:
-            // https://youtrack.jetbrains.com/issue/KT-32805#focus=Comments-27-5915479.0-0
-            val (majorVersion, minorVersion) = getKotlinPluginVersion()
-                .split('.')
-                .take(2)
-                .map { it.toInt() }
-            if (majorVersion == 1 && minorVersion < 7) {
-                (tasks.findByName(compilation.compileKotlinTaskName) as? AbstractCompile)?.classpath =
-                    originalMainClassesDirs + compilation.compileDependencyFiles - mainCompilation.output.classesDirs
-            } else {
-                (tasks.findByName(compilation.compileKotlinTaskName) as? AbstractKotlinCompileTool<*>)
-                    ?.libraries
-                    ?.setFrom(
-                        originalMainClassesDirs + compilation.compileDependencyFiles
-                    )
-            }
+            (tasks.findByName(compilation.compileKotlinTaskName) as? AbstractKotlinCompileTool<*>)
+                ?.libraries
+                ?.setFrom(
+                    originalMainClassesDirs + compilation.compileDependencyFiles
+                )
 
             (tasks.findByName("${target.name}${compilation.name.capitalize()}") as? Test)?.classpath =
                 originalMainClassesDirs + (compilation as KotlinCompilationToRunnableFiles).runtimeDependencyFiles - mainCompilation.output.classesDirs

--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/internal/Assert.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/internal/Assert.kt
@@ -28,5 +28,9 @@ internal fun BuildResult.assertTaskUpToDate(task: String) {
 }
 
 private fun BuildResult.assertTaskOutcome(taskOutcome: TaskOutcome, taskName: String) {
-    assertEquals(taskOutcome, task(taskName)?.outcome)
+    assertEquals(
+        taskOutcome,
+        task(taskName)?.outcome,
+        "Task $taskName does not have ${taskOutcome.name} outcome"
+    )
 }

--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JvmProjectTest.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JvmProjectTest.kt
@@ -35,7 +35,7 @@ class JvmLegacyTransformationTest : BaseKotlinGradleTest("jvm-simple") {
         checkTaskOutcomes(
             executedTasks = listOf(
                 ":compileKotlin",
-                ":transformAtomicfu",
+                ":transformMainAtomicfu",
                 ":compileTestKotlin",
                 ":transformTestAtomicfu"
             ),
@@ -46,7 +46,7 @@ class JvmLegacyTransformationTest : BaseKotlinGradleTest("jvm-simple") {
     fun testClasspath() {
         runner.build()
         checkJvmCompilationClasspath(
-            originalClassFile = "build/classes/kotlin/main/IntArithmetic.class",
+            originalClassFile = "build/classes/atomicfu-orig/main/IntArithmetic.class",
             transformedClassFile = "build/classes/atomicfu/main/IntArithmetic.class"
         )
     }
@@ -103,6 +103,6 @@ class JvmIrTransformationTest : BaseKotlinGradleTest("jvm-simple") {
     @Test
     fun testAtomicfuReferences() {
         runner.build()
-        checkBytecode("build/classes/kotlin/main/IntArithmetic.class")
+        checkBytecode("build/classes/atomicfu-orig/main/IntArithmetic.class")
     }
 }

--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JvmProjectTest.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JvmProjectTest.kt
@@ -35,9 +35,9 @@ class JvmLegacyTransformationTest : BaseKotlinGradleTest("jvm-simple") {
         checkTaskOutcomes(
             executedTasks = listOf(
                 ":compileKotlin",
-                ":transformAtomicfuClasses",
+                ":transformAtomicfu",
                 ":compileTestKotlin",
-                ":transformTestAtomicfuClasses"
+                ":transformTestAtomicfu"
             ),
             excludedTasks = emptyList()
         )
@@ -95,8 +95,8 @@ class JvmIrTransformationTest : BaseKotlinGradleTest("jvm-simple") {
                 ":compileTestKotlin"
             ),
             excludedTasks = listOf(
-                ":transformAtomicfuClasses",
-                ":transformTestAtomicfuClasses"
+                ":transformAtomicfu",
+                ":transformTestAtomicfu"
             )
         )
 

--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/MppProjectTest.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/MppProjectTest.kt
@@ -50,7 +50,7 @@ class MppLegacyTransformationTest : BaseKotlinGradleTest("mpp-simple") {
     fun testClasspath() {
         runner.build()
         checkJvmCompilationClasspath(
-            originalClassFile = "build/classes/kotlin/jvm/main/IntArithmetic.class",
+            originalClassFile = "build/classes/atomicfu-orig/jvm/main/IntArithmetic.class",
             transformedClassFile = "build/classes/atomicfu/jvm/main/IntArithmetic.class"
         )
         checkJsCompilationClasspath()
@@ -112,7 +112,7 @@ class MppJvmIrTransformationTest : BaseKotlinGradleTest("mpp-simple") {
     @Test
     fun testAtomicfuReferences() {
         runner.build()
-        checkBytecode("build/classes/kotlin/jvm/main/IntArithmetic.class")
+        checkBytecode("build/classes/atomicfu-orig/jvm/main/IntArithmetic.class")
     }
 }
 
@@ -217,6 +217,6 @@ class MppBothIrTransformationTest : BaseKotlinGradleTest("mpp-simple") {
     @Test
     fun testAtomicfuReferences() {
         runner.build()
-        checkBytecode("build/classes/kotlin/jvm/main/IntArithmetic.class")
+        checkBytecode("build/classes/atomicfu-orig/jvm/main/IntArithmetic.class")
     }
 }

--- a/atomicfu-gradle-plugin/src/test/resources/projects/jvm-simple/jvm-simple.gradle.kts
+++ b/atomicfu-gradle-plugin/src/test/resources/projects/jvm-simple/jvm-simple.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
 }
 
 kotlin {
+    java {
+        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+    }
+
     tasks.compileTestKotlin {
         doLast {
             file("$buildDir/test_compile_jvm_classpath.txt").writeText(


### PR DESCRIPTION
After update from Gradle 6.8 to 7.3 the problem with building jvm-only projects was found: jar task is failing with this error
```
Execution failed for task ':jar'.
> Entry IntArithmetic.class is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.3/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```

Reproduced with Kotlin 1.8.20+

Jar task tries to pack both original and transformed class files.

Fixes #301, #295
