### PR TITLE
Revert "Ignore testClasspath(), fails with LV 1.9. Will be fixed via …

### DIFF
--- a/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JvmProjectTest.kt
+++ b/atomicfu-gradle-plugin/src/test/kotlin/kotlinx/atomicfu/plugin/gradle/test/JvmProjectTest.kt
@@ -2,7 +2,6 @@ package kotlinx.atomicfu.plugin.gradle.test
 
 import kotlinx.atomicfu.plugin.gradle.internal.*
 import kotlinx.atomicfu.plugin.gradle.internal.BaseKotlinScope
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -44,7 +43,6 @@ class JvmLegacyTransformationTest : BaseKotlinGradleTest("jvm-simple") {
         )
 
     @Test
-    @Ignore
     fun testClasspath() {
         runner.build()
         checkJvmCompilationClasspath(


### PR DESCRIPTION
…- https://github.com/Kotlin/kotlinx-atomicfu/issues/295"

This reverts commit 3b9c3d3bc5db8c4a2abf0bb7ae1e3e21f25d5a16.