### PR TITLE
Update native atomics implementation

### DIFF
--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -6,9 +6,9 @@
 
 package kotlinx.atomicfu
 
-import kotlin.native.concurrent.AtomicInt as KAtomicInt
-import kotlin.native.concurrent.AtomicLong as KAtomicLong
-import kotlin.native.concurrent.FreezableAtomicReference as KAtomicRef
+import kotlin.concurrent.AtomicInt as KAtomicInt
+import kotlin.concurrent.AtomicLong as KAtomicLong
+import kotlin.concurrent.AtomicReference as KAtomicRef
 import kotlin.native.concurrent.isFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.reflect.KProperty
@@ -53,7 +53,7 @@ public actual value class AtomicRef<T> internal constructor(@PublishedApi intern
         while (true) {
             val cur = a.value
             if (cur === value) return cur
-            if (a.compareAndSwap(cur, value) === cur) return cur
+            if (a.compareAndExchange(cur, value) === cur) return cur
         }
     }
 
@@ -155,12 +155,12 @@ public actual value class AtomicLong internal constructor(@PublishedApi internal
         }
     }
 
-    public actual inline fun getAndIncrement(): Long = a.addAndGet(1) - 1
-    public actual inline fun getAndDecrement(): Long = a.addAndGet(-1) + 1
+    public actual inline fun getAndIncrement(): Long = a.addAndGet(1L) - 1
+    public actual inline fun getAndDecrement(): Long = a.addAndGet(-1L) + 1
     public actual inline fun getAndAdd(delta: Long): Long = a.addAndGet(delta) - delta
     public actual inline fun addAndGet(delta: Long): Long = a.addAndGet(delta)
-    public actual inline fun incrementAndGet(): Long = a.addAndGet(1)
-    public actual inline fun decrementAndGet(): Long = a.addAndGet(-1)
+    public actual inline fun incrementAndGet(): Long = a.addAndGet(1L)
+    public actual inline fun decrementAndGet(): Long = a.addAndGet(-1L)
 
     public actual inline operator fun plusAssign(delta: Long) { getAndAdd(delta) }
     public actual inline operator fun minusAssign(delta: Long) { getAndAdd(-delta) }

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/Synchronized.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/Synchronized.kt
@@ -3,9 +3,13 @@ package kotlinx.atomicfu.locks
 import platform.posix.*
 import interop.*
 import kotlinx.cinterop.*
-import kotlin.native.concurrent.*
+import kotlin.concurrent.*
 import kotlin.native.internal.NativePtr
 import kotlinx.atomicfu.locks.SynchronizedObject.Status.*
+import kotlin.concurrent.AtomicNativePtr
+import kotlin.concurrent.AtomicReference
+import kotlin.native.SharedImmutable
+import kotlin.native.concurrent.*
 
 public actual open class SynchronizedObject {
 


### PR DESCRIPTION
This commit replaces deprecated native atomics from `kotlin.native.concurrent` package with new atomics from `kotlin.concurrent`, because deprecation levels of native atomics will be updated for 1.9.20 in this MR (https://jetbrains.team/p/kt/reviews/10650/timeline), see KT-58123. These changes are required in `kotlin-community/dev` branch for the aggregate build to pass.

NOTE: this commit is not present in develop branch, because new `kotlin.concurrent` atomics are only available since Kotlin 1.9.0. IT SHOULD BE REMOVED after kotlinx.atomicfu updates Kotlin version to 1.9.0 (#313)