### PR TITLE
Updated gradle-node-plugin to be compatible with Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.moowork.gradle:gradle-node-plugin:$gradle_node_version"
+        classpath "com.github.node-gradle:gradle-node-plugin:$gradle_node_version"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinx_metadata_version=0.6.0
 
 maven_version=3.5.3
 
-gradle_node_version=1.2.0
+gradle_node_version=3.1.1
 node_version=8.11.1
 npm_version=5.7.1
 mocha_version=4.1.0

--- a/gradle/node-js.gradle
+++ b/gradle/node-js.gradle
@@ -2,7 +2,8 @@
  * Copyright 2017-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-apply plugin: 'com.moowork.node'
+apply plugin: 'com.github.node-gradle.node'
+
 
 node {
     version = "$node_version"


### PR DESCRIPTION
There was a breaking change introduced in Gradle 6.8, that caused atomicfu:nodeSetup task to fail with unresolved layout() method. This commit replaces `com.moowork.gradle:gradle-node-plugin` with `com.github.node-gradle:gradle-node-plugin`