### PR TITLE
[Reopened PR #314] Update native atomic deprecations

### DIFF
--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/AtomicFU.kt
@@ -6,9 +6,9 @@
 
 package kotlinx.atomicfu
 
-import kotlin.native.concurrent.AtomicInt as KAtomicInt
-import kotlin.native.concurrent.AtomicLong as KAtomicLong
-import kotlin.native.concurrent.FreezableAtomicReference as KAtomicRef
+import kotlin.concurrent.AtomicInt as KAtomicInt
+import kotlin.concurrent.AtomicLong as KAtomicLong
+import kotlin.concurrent.AtomicReference as KAtomicRef
 import kotlin.native.concurrent.isFrozen
 import kotlin.native.concurrent.freeze
 import kotlin.reflect.KProperty
@@ -53,7 +53,7 @@ public actual value class AtomicRef<T> internal constructor(@PublishedApi intern
         while (true) {
             val cur = a.value
             if (cur === value) return cur
-            if (a.compareAndSwap(cur, value) === cur) return cur
+            if (a.compareAndExchange(cur, value) === cur) return cur
         }
     }
 
@@ -155,12 +155,12 @@ public actual value class AtomicLong internal constructor(@PublishedApi internal
         }
     }
 
-    public actual inline fun getAndIncrement(): Long = a.addAndGet(1) - 1
-    public actual inline fun getAndDecrement(): Long = a.addAndGet(-1) + 1
+    public actual inline fun getAndIncrement(): Long = a.addAndGet(1L) - 1
+    public actual inline fun getAndDecrement(): Long = a.addAndGet(-1L) + 1
     public actual inline fun getAndAdd(delta: Long): Long = a.addAndGet(delta) - delta
     public actual inline fun addAndGet(delta: Long): Long = a.addAndGet(delta)
-    public actual inline fun incrementAndGet(): Long = a.addAndGet(1)
-    public actual inline fun decrementAndGet(): Long = a.addAndGet(-1)
+    public actual inline fun incrementAndGet(): Long = a.addAndGet(1L)
+    public actual inline fun decrementAndGet(): Long = a.addAndGet(-1L)
 
     public actual inline operator fun plusAssign(delta: Long) { getAndAdd(delta) }
     public actual inline operator fun minusAssign(delta: Long) { getAndAdd(-delta) }

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/Synchronized.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/Synchronized.kt
@@ -3,9 +3,13 @@ package kotlinx.atomicfu.locks
 import platform.posix.*
 import interop.*
 import kotlinx.cinterop.*
-import kotlin.native.concurrent.*
+import kotlin.concurrent.*
 import kotlin.native.internal.NativePtr
 import kotlinx.atomicfu.locks.SynchronizedObject.Status.*
+import kotlin.concurrent.AtomicNativePtr
+import kotlin.concurrent.AtomicReference
+import kotlin.native.SharedImmutable
+import kotlin.native.concurrent.*
 
 public actual open class SynchronizedObject {
 

--- a/gradle/compile-options.gradle
+++ b/gradle/compile-options.gradle
@@ -18,8 +18,8 @@ ext.configureKotlin = { isMultiplatform ->
 
     kotlin.sourceSets.all {
         languageSettings {
-            apiVersion = KotlinAggregateBuild.getOverriddenKotlinApiVersion(project) ?: "1.4"
-            languageVersion = KotlinAggregateBuild.getOverriddenKotlinLanguageVersion(project) ?: "1.4"
+            apiVersion = KotlinAggregateBuild.getOverriddenKotlinApiVersion(project) ?: "1.9"
+            languageVersion = KotlinAggregateBuild.getOverriddenKotlinLanguageVersion(project) ?: "1.9"
             optIn('kotlinx.cinterop.ExperimentalForeignApi')
         }
     }


### PR DESCRIPTION
The commit from #314 was reverted after merge, because it caused the aggregate build to fail (apiVersion = 1.9 was required to use new native atomics, but it was 1.4 in the project), thus I've commited the apiVersion update to the same branch and reopened the PR.

This is the [test aggregate build](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinDev_kotlinxAtomicfu/322865301?hideProblemsFromDependencies=false&hideTestsFromDependencies=false) that checks atomicfu part of the aggregate build against the current branch before merge to `kotlin-community/dev`.

This problem could be revealed before merge if `kotlin-community/dev` branch relied on the existing Kotlin version, rather then dev versions that may be already removed, I've filed the issue for that: #315.

P.S. This is the MR with deprecation level updates for new native atomics that requires these changes: https://jetbrains.team/p/kt/reviews/10650/timeline.