### PR TITLE
Conditionally remove targets that are deprecated after 1.9.0.

### DIFF
--- a/atomicfu-gradle-plugin/build.gradle
+++ b/atomicfu-gradle-plugin/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 }
 
 // Skip these tests if Kotlin version >= 1.9.0, as JS Legacy is no longer supported there
-if (isKotlinVersionAtLeast(ext.kotlin_version, 1, 9)) {
+if (isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 0)) {
     test {
         exclude "**/JsLegacyTransformationTest*", "**/MppLegacyTransformationTest*"
     }

--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -22,7 +22,7 @@ ext {
 
 // TODO: this block should be removed when Kotlin version is updated to 1.9.0
 // (right now it implements a toggle between IR and BOTH JS compiler types for testing of Kotlin dev builds)
-def isJsLegacyCompilerEnabled = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9)
+def isKotlinLowerThan_1_9_0 = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9)
 
 kotlin {
     targets {
@@ -34,7 +34,7 @@ kotlin {
     // JS -- always
     // TODO: JS compiler should be switched to IR-only when Kotlin version is updated to 1.9.0
     // (right now compiler type is chosen conditionally for testing of Kotlin dev builds)
-    def jsCompiler = isJsLegacyCompilerEnabled ? BOTH : IR
+    def jsCompiler = isKotlinLowerThan_1_9_0 ? BOTH : IR
     js(jsCompiler) {
         moduleName = "kotlinx-atomicfu"
         // TODO: Commented out because browser tests do not work on TeamCity
@@ -119,9 +119,11 @@ if (rootProject.ext.native_targets_enabled) {
                 addTarget(presets.mingwX64)
                 addTarget(presets.watchosDeviceArm64)
 
-                // Deprecated, remove after 1.9.0
-                addTarget(presets.iosArm32)
-                addTarget(presets.watchosX86)
+                if (isKotlinLowerThan_1_9_0) {
+                    // Deprecated, remove after 1.9.0
+                    addTarget(presets.iosArm32)
+                    addTarget(presets.watchosX86)
+                }
             }
         }
 
@@ -165,7 +167,7 @@ dependencies {
 
 // TODO: This JS Legacy configuration should be removed when Kotlin version is updated to 1.9.0,
 // (right now configurations are removed conditionally for testing of Kotlin 1.9.0-dev builds)
-if (isJsLegacyCompilerEnabled) {
+if (isKotlinLowerThan_1_9_0) {
 
     // ==== CONFIGURE JS =====
 

--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -21,9 +21,12 @@ ext {
 }
 
 // TODO: this block should be removed when Kotlin version is updated to 1.9.0
-// (right now it implements a toggle between IR and BOTH JS compiler types for testing of Kotlin dev builds)
-def isKotlinLowerThan_1_9_0 = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 0)
-def isKotlinLowerThan_1_9_20 = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 20)
+// Right now it implements a toggle between IR and BOTH JS compiler types for testing of Kotlin dev builds
+def isJsLegacyCompilerEnabled = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 0)
+// TODO: this block should be removed when Kotlin version is updated to 1.9.20
+// Right now it is used for conditional removal of native targets that will be removed in 1.9.20 (iosArm32, watchosX86)
+// and is necessary for testing of Kotlin dev builds.
+def enableDeprecatedNativeTargets = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 20)
 
 kotlin {
     targets {
@@ -35,7 +38,7 @@ kotlin {
     // JS -- always
     // TODO: JS compiler should be switched to IR-only when Kotlin version is updated to 1.9.0
     // (right now compiler type is chosen conditionally for testing of Kotlin dev builds)
-    def jsCompiler = isKotlinLowerThan_1_9_0 ? BOTH : IR
+    def jsCompiler = isJsLegacyCompilerEnabled ? BOTH : IR
     js(jsCompiler) {
         moduleName = "kotlinx-atomicfu"
         // TODO: Commented out because browser tests do not work on TeamCity
@@ -121,7 +124,7 @@ if (rootProject.ext.native_targets_enabled) {
                 addTarget(presets.watchosDeviceArm64)
 
                 // These targets will be removed in 1.9.20, remove them conditionally for the train builds
-                if (isKotlinLowerThan_1_9_20) {
+                if (enableDeprecatedNativeTargets) {
                     addTarget(presets.iosArm32)
                     addTarget(presets.watchosX86)
                 }
@@ -168,7 +171,7 @@ dependencies {
 
 // TODO: This JS Legacy configuration should be removed when Kotlin version is updated to 1.9.0,
 // (right now configurations are removed conditionally for testing of Kotlin 1.9.0-dev builds)
-if (isKotlinLowerThan_1_9_0) {
+if (isJsLegacyCompilerEnabled) {
 
     // ==== CONFIGURE JS =====
 

--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -22,7 +22,8 @@ ext {
 
 // TODO: this block should be removed when Kotlin version is updated to 1.9.0
 // (right now it implements a toggle between IR and BOTH JS compiler types for testing of Kotlin dev builds)
-def isKotlinLowerThan_1_9_0 = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9)
+def isKotlinLowerThan_1_9_0 = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 0)
+def isKotlinLowerThan_1_9_20 = !isKotlinVersionAtLeast(ext.kotlin_version, 1, 9, 20)
 
 kotlin {
     targets {
@@ -119,8 +120,8 @@ if (rootProject.ext.native_targets_enabled) {
                 addTarget(presets.mingwX64)
                 addTarget(presets.watchosDeviceArm64)
 
-                if (isKotlinLowerThan_1_9_0) {
-                    // Deprecated, remove after 1.9.0
+                // These targets will be removed in 1.9.20, remove them conditionally for the train builds
+                if (isKotlinLowerThan_1_9_20) {
                     addTarget(presets.iosArm32)
                     addTarget(presets.watchosX86)
                 }

--- a/buildSrc/src/main/kotlin/KotlinVersion.kt
+++ b/buildSrc/src/main/kotlin/KotlinVersion.kt
@@ -1,13 +1,14 @@
 @file:JvmName("KotlinVersion")
 
-fun isKotlinVersionAtLeast(kotlinVersion: String, atLeastMajor: Int, atLeastMinor: Int): Boolean {
+fun isKotlinVersionAtLeast(kotlinVersion: String, atLeastMajor: Int, atLeastMinor: Int, atLeastPatch: Int): Boolean {
     val (major, minor) = kotlinVersion
         .split('.')
         .take(2)
         .map { it.toInt() }
+    val patch = kotlinVersion.substringAfterLast('.').substringBefore('-').toInt()
     return when {
         major > atLeastMajor -> true
         major < atLeastMajor -> false
-        else -> minor >= atLeastMinor
+        else -> (minor == atLeastMinor && patch >= atLeastPatch) || minor > atLeastMinor
     }
 }


### PR DESCRIPTION
Native targets `iosArm32` and `watchosX86` are deprecated in 1.9.0.
This commit removes them conditionally in case Kotlin version  >= 1.9.0.

This is necessary for the kotlin-community/* train branches that use Kotlin 1.9.* versions in builds.