### PR TITLE
Remove obsolete no longer supported kotlin.mpp.enableCompatibilityMe…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,8 @@ mocha_headless_chrome_version=1.8.2
 mocha_teamcity_reporter_version=2.2.2
 source_map_support_version=0.5.3
 
-kotlin.incremental.multiplatform=true
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.mpp.enableCompatibilityMetadataVariant=true
 kotlin.mpp.enableCInteropCommonization=true
 
 # Workaround for Bintray treating .sha512 files as artifacts


### PR DESCRIPTION
…tadataVariant that will be removed in 1.9.20