### PR TITLE
Update kotlinx.metadata to 0.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ kotlin_version=1.8.20
 asm_version=9.3
 slf4j_version=1.8.0-alpha2
 junit_version=4.12
-kotlinx_metadata_version=0.6.0
+kotlinx_metadata_version=0.7.0
 
 maven_version=3.5.3
 


### PR DESCRIPTION
`kotlinx.metadata` version update is required to fix the problem with K2 build of ktor: https://youtrack.jetbrains.com/issue/KT-60444/transformJvmMainAtomicfu-fails-with-java.lang.NoSuchMethodError-kotlin.Metadata