### PR TITLE
Use kotlin.concurrent.AtomicInt in SynchronizedTest

### DIFF
--- a/atomicfu/src/nativeTest/kotlin/kotlinx/atomicfu/locks/SynchronizedTest.kt
+++ b/atomicfu/src/nativeTest/kotlin/kotlinx/atomicfu/locks/SynchronizedTest.kt
@@ -1,5 +1,6 @@
 package kotlinx.atomicfu.locks
 
+import kotlin.concurrent.AtomicInt
 import kotlin.native.concurrent.*
 import kotlin.test.*
 


### PR DESCRIPTION
Atomics from kotlin.native.concurrent package are deprecated with error since 1.9.20

See KT-58123