### PR TITLE
Sign publication failure again

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -55,14 +55,27 @@ publishing {
     publications.all {
         PublishingKt.configureMavenCentralMetadata(pom, project)
         PublishingKt.signPublicationIfKeyPresent(project, it)
-
         // add empty javadocs
         if (it.name != "kotlinMultiplatform") { // The root module gets the JVM's javadoc JAR
             it.artifact(javadocJar)
         }
     }
 
-    tasks.withType(PublishToMavenRepository).configureEach {
+    tasks.withType(AbstractPublishToMaven).configureEach {
         dependsOn(tasks.withType(Sign))
+    }
+
+    // NOTE: This is a temporary WA, see KT-61313.
+    tasks.withType(Sign).configureEach { signTask ->
+        def pubName = name.takeBetween("sign", "Publication")
+
+        // Task ':linkDebugTest<platform>' uses this output of task ':sign<platform>Publication' without declaring an explicit or implicit dependency
+        tasks.findByName("linkDebugTest$pubName")?.configure {
+            mustRunAfter(signTask)
+        }
+        // Task ':compileTestKotlin<platform>' uses this output of task ':sign<platform>Publication' without declaring an explicit or implicit dependency
+        tasks.findByName("compileTestKotlin$pubName")?.configure {
+            mustRunAfter(signTask)
+        }
     }
 }

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -50,12 +50,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
-kotlin {
-    jvmToolchain(11)
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {
@@ -80,4 +76,14 @@ task mavenTest(type: Test) {
     def sourceSet = sourceSets.mavenTest
     testClassesDirs = sourceSet.output.classesDirs
     classpath = sourceSet.runtimeClasspath
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -50,8 +50,12 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    jvmToolchain(11)
 }
 
 dependencies {
@@ -76,14 +80,4 @@ task mavenTest(type: Test) {
     def sourceSet = sourceSets.mavenTest
     testClassesDirs = sourceSet.output.classesDirs
     classpath = sourceSet.runtimeClasspath
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }


### PR DESCRIPTION
This issue was revealed after enabling integration testing of atomicfu. Now the first TC build step executes `build` and `publishToMavenLocal` tasks. `publishToMavenLocal` task fails with an error: 
```
Reason: Task ':atomicfu:compileTestKotlinLinuxX64' uses this output of task ':atomicfu:signLinuxX64Publication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

This is an already known problem [KT-61313](https://youtrack.jetbrains.com/issue/KT-61313) caused by the task configuration performed by KGP.


This fix is necessary to be able to launch integration tests added in this PR: #344 