### PR TITLE
Upgrade JDK target version to 11 in integration tests.

### DIFF
--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -50,8 +50,12 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    jvmToolchain(11)
 }
 
 dependencies {
@@ -76,14 +80,4 @@ task mavenTest(type: Test) {
     def sourceSet = sourceSets.mavenTest
     testClassesDirs = sourceSet.output.classesDirs
     classpath = sourceSet.runtimeClasspath
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }


### PR DESCRIPTION
Api used in MavenPublicationMetaInfValidator requires JDK10+