### PR TITLE
Fix the WA for the failing clean task on Windows

### DIFF
--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -398,7 +398,8 @@ tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
 
 // Workaround for https://youtrack.jetbrains.com/issue/KT-58303:
 // the `clean` task can't delete the expanded.lock file on Windows as it's still held by Gradle, failing the build
-clean {
-    delete.add(fileTree(buildDir))
-    delete.remove("tmp/.cache/expanded/expanded.lock")
+tasks.clean {
+    setDelete(layout.buildDirectory.asFileTree.matching {
+        exclude("tmp/.cache/expanded/expanded.lock")
+    })
 }


### PR DESCRIPTION
This commit fixes the WA for the failure of clean task on Windows (KT-58303), properly excluding the directory for the Delete task.