### PR TITLE
Flag for Native IR integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Starting from version `0.22.0` of the library your project is required to use:
 * Code it like a boxed value `atomic(0)`, but run it in production efficiently:
   * For **JVM**: an atomic value is represented as a plain value atomically updated with `java.util.concurrent.atomic.AtomicXxxFieldUpdater` from the Java standard library.
   * For **JS**: an atomic value is represented as a plain value.
-  * For **Native** and **Wasm**: an atomic value is not transformed, it remains boxed, and `kotlinx-atomicfu` library is used as a runtime dependency.
+  * For **Native**: atomic operations are delegated to Kotlin/Native atomic intrinsics.
+  * For **Wasm**: an atomic value is not transformed, it remains boxed, and `kotlinx-atomicfu` library is used as a runtime dependency.
 * Use Kotlin-specific extensions (e.g. inline `loop`, `update`, `updateAndGet` functions).
 * Use atomic arrays, user-defined extensions on atomics and locks (see [more features](#more-features)).
 * [Tracing operations](#tracing-operations) for debugging.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 >We do provide a compatibility of atomicfu-transformed artifacts between releases, but we do not provide 
 >strict compatibility guarantees on plugin API and its general stability between Kotlin versions.
 
-**Atomicfu** is a multiplatform library that provides the idiomatic and effective way of using atomic operations in Kotlin.
+**Atomicfu** is a multiplatform library that provides the idiomatic and efficient way of using atomic operations in Kotlin.
 
 ## Table of contents
 - [Requirements](#requirements)
@@ -247,17 +247,13 @@ public var foo: T by _foo            // public delegated property (val/var)
   (more specifically, `complex_expression` should not have branches in its compiled representation).
   Extract `complex_expression` into a variable when needed.
 
-## Transformation modes
+## Atomicfu compiler plugin
 
-Basically, Atomicfu library provides an effective usage of atomic values by performing the transformations of the compiled code.
-For JVM and JS there 2 transformation modes available: 
-* **Post-compilation transformation** that modifies the compiled bytecode or `*.js` files. 
-* **IR transformation** that is performed by the atomicfu compiler plugin.
-
-### Atomicfu compiler plugin
-
-Compiler plugin transformation is less fragile than transformation of the compiled sources 
-as it depends on the compiler IR tree.
+To provide a user-friendly atomic API on the frontend and efficient usage of atomic values on the backend kotlinx-atomicfu library uses the compiler plugin to transform 
+IR for all the target backends: 
+* **JVM**: atomics are replaced with `java.util.concurrent.atomic.AtomicXxxFieldUpdater`.
+* **Native**: atomics are implemented via atomic intrinsics on Kotlin/Native.
+* **JS**: atomics are unboxed and represented as plain values.
 
 To turn on IR transformation set these properties in your `gradle.properties` file:
 
@@ -266,6 +262,7 @@ To turn on IR transformation set these properties in your `gradle.properties` fi
 
 ```groovy
 kotlinx.atomicfu.enableJvmIrTransformation=true // for JVM IR transformation
+kotlinx.atomicfu.enableNativeIrTransformation=true // for Native IR transformation
 kotlinx.atomicfu.enableJsIrTransformation=true // for JS IR transformation
 ```
 

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
@@ -48,4 +48,22 @@ class MppProjectTest {
         mppSample.checkMppWasmJsImplementationDependencies()
         mppSample.checkMppWasmWasiImplementationDependencies()
     }
+
+    @Test
+    fun testMppNativeWithEnabledIrTransformation() {
+        mppSample.enableNativeIrTransformation = true
+        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.checkMppNativeCompileOnlyDependencies()
+        // TODO: klib checks are skipped for now because of this problem KT-61143
+        //mppSample.buildAndCheckNativeKlib()
+    }
+
+    @Test
+    fun testMppNativeWithDisabledIrTransformation() {
+        mppSample.enableNativeIrTransformation = false
+        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.checkMppNativeImplementationDependencies()
+        // TODO: klib checks are skipped for now because of this problem KT-61143
+        //mppSample.buildAndCheckNativeKlib()
+    }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
@@ -62,7 +62,7 @@ internal fun GradleBuild.checkMppWasmWasiImplementationDependencies() {
 // Checks Native target of an MPP project
 internal fun GradleBuild.checkMppNativeCompileOnlyDependencies() {
     // Here the name of the native target is hardcoded because the tested mpp-sample project declares this target and
-    // KGP generates the same set of depependencies for every declared native target ([mingwX64|linuxX64|macosX64...]CompileKlibraries)
+    // KGP generates the same set of dependencies for every declared native target ([mingwX64|linuxX64|macosX64...]CompileKlibraries)
     checkAtomicfuDependencyIsPresent(listOf("macosX64CompileKlibraries"), commonAtomicfuDependency)
     checkAtomicfuDependencyIsAbsent(listOf("macosX64MainImplementation"), commonAtomicfuDependency)
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
@@ -59,6 +59,19 @@ internal fun GradleBuild.checkMppWasmWasiImplementationDependencies() {
     checkAtomicfuDependencyIsPresent(listOf("wasmWasiCompileClasspath", "wasmWasiRuntimeClasspath"), commonAtomicfuDependency)
 }
 
+// Checks Native target of an MPP project
+internal fun GradleBuild.checkMppNativeCompileOnlyDependencies() {
+    // Here the name of the native target is hardcoded because the tested mpp-sample project declares this target and
+    // KGP generates the same set of depependencies for every declared native target ([mingwX64|linuxX64|macosX64...]CompileKlibraries)
+    checkAtomicfuDependencyIsPresent(listOf("macosX64CompileKlibraries"), commonAtomicfuDependency)
+    checkAtomicfuDependencyIsAbsent(listOf("macosX64MainImplementation"), commonAtomicfuDependency)
+}
+
+// Checks Native target of an MPP project
+internal fun GradleBuild.checkMppNativeImplementationDependencies() {
+    checkAtomicfuDependencyIsPresent(listOf("macosX64CompileKlibraries", "macosX64MainImplementation"), commonAtomicfuDependency)
+}
+
 // Some dependencies may be not resolvable but consumable and will not be present in the output of :dependencies task,
 // in this case we should check .pom or .module file of the published project.
 // This method checks if the .module file in the sample project publication contains org.jetbrains.kotlinx:atomicfu dependency included.


### PR DESCRIPTION
Support of the `enableNativeIrTransformation` flag that enables Native Ir Transformation by the compiler plugin.
