### PR TITLE
Enable error loglevel for partial linkage messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,13 @@ allprojects {
             }
         }
     }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile).configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    }
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile).configureEach {
+        compilerOptions { freeCompilerArgs.add("-Xpartial-linkage-loglevel=ERROR") }
+    }
 }
 
 if (build_snapshot_train) {


### PR DESCRIPTION
The change is related to building kotlinx-atomicfu as a Kotlin user project.
See [QA-1106](https://youtrack.jetbrains.com/issue/QA-1106) for more details.