### PR TITLE
Always add a transitive atomicfu dependency for native targets.

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -159,7 +159,7 @@ private fun Project.configureMultiplatformPluginDependencies(version: String) {
     }
     // Include atomicfu as a dependency for publication when transformation for the target is disabled
     multiplatformExtension.targets.all { target ->
-        if (isTransformationDisabled(target)) {
+        if (isTransitiveAtomicfuDependencyRequired(target)) {
             target.compilations.all { compilation ->
                 compilation
                     .defaultSourceSet
@@ -215,12 +215,13 @@ private fun KotlinTarget.isJsIrTarget() =
     (this is KotlinJsTarget && this.irTarget != null) ||
             (this is KotlinJsIrTarget && this.platformType != KotlinPlatformType.wasm)
 
-private fun Project.isTransformationDisabled(target: KotlinTarget): Boolean {
+private fun Project.isTransitiveAtomicfuDependencyRequired(target: KotlinTarget): Boolean {
     val platformType = target.platformType
     return !config.transformJvm && (platformType == KotlinPlatformType.jvm || platformType == KotlinPlatformType.androidJvm) ||
             !config.transformJs && platformType == KotlinPlatformType.js ||
             platformType == KotlinPlatformType.wasm ||
-            !needsNativeIrTransformation(target) && platformType == KotlinPlatformType.native
+            // Always add the transitive atomicfu dependency for native targets, see #379
+            platformType == KotlinPlatformType.native
 }
 
 // Adds kotlinx-atomicfu-runtime as an implementation dependency to the JS IR target:

--- a/integration-testing/examples/mpp-sample/src/commonMain/kotlin/AtomicSampleClass.kt
+++ b/integration-testing/examples/mpp-sample/src/commonMain/kotlin/AtomicSampleClass.kt
@@ -2,17 +2,26 @@
  * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+package kotlinx.atomicfu.examples.mpp_sample
+
 import kotlinx.atomicfu.*
+import kotlinx.atomicfu.locks.*
 import kotlin.test.*
 
-class IntArithmetic {
+public class AtomicSampleClass {
     private val _x = atomic(0)
     val x get() = _x.value
 
-    fun doWork(finalValue: Int) {
+    public fun doWork(finalValue: Int) {
         assertEquals(0, x)
         assertEquals(0, _x.getAndSet(3))
         assertEquals(3, x)
         assertTrue(_x.compareAndSet(3, finalValue))
+    }
+    
+    private val lock = reentrantLock()
+    
+    public fun synchronizedFoo(value: Int): Int {
+        return lock.withLock { value }
     }
 }

--- a/integration-testing/examples/mpp-sample/src/commonMain/kotlin/AtomicSampleClass.kt
+++ b/integration-testing/examples/mpp-sample/src/commonMain/kotlin/AtomicSampleClass.kt
@@ -2,7 +2,7 @@
  * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-package kotlinx.atomicfu.examples.mpp_sample
+package examples.mpp_sample
 
 import kotlinx.atomicfu.*
 import kotlinx.atomicfu.locks.*

--- a/integration-testing/examples/mpp-sample/src/commonTest/kotlin/AtomicSampleTest.kt
+++ b/integration-testing/examples/mpp-sample/src/commonTest/kotlin/AtomicSampleTest.kt
@@ -3,13 +3,15 @@
  */
 
 import kotlin.test.*
+import kotlinx.atomicfu.examples.mpp_sample.*
 
-class IntArithmeticTest {
+class AtomicSampleTest {
 
     @Test
     fun testInt() {
-        val a = IntArithmetic()
+        val a = AtomicSampleClass()
         a.doWork(1234)
         assertEquals(1234, a.x)
+        assertEquals(42, a.synchronizedFoo(42))
     }
 }

--- a/integration-testing/examples/mpp-sample/src/commonTest/kotlin/AtomicSampleTest.kt
+++ b/integration-testing/examples/mpp-sample/src/commonTest/kotlin/AtomicSampleTest.kt
@@ -3,7 +3,7 @@
  */
 
 import kotlin.test.*
-import kotlinx.atomicfu.examples.mpp_sample.*
+import examples.mpp_sample.*
 
 class AtomicSampleTest {
 

--- a/integration-testing/examples/user-project/build.gradle.kts
+++ b/integration-testing/examples/user-project/build.gradle.kts
@@ -40,3 +40,9 @@ kotlin {
         commonTest {}
     }
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xskip-prerelease-check")
+    }
+}

--- a/integration-testing/examples/user-project/build.gradle.kts
+++ b/integration-testing/examples/user-project/build.gradle.kts
@@ -8,7 +8,10 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
-    maven("../mpp-sample/build/.m2/")
+    val localRepositoryUrl = findProperty("localRepositoryUrl")
+    if (localRepositoryUrl != null) {
+        maven(localRepositoryUrl)   
+    }
     mavenLocal()
 }
 

--- a/integration-testing/examples/user-project/build.gradle.kts
+++ b/integration-testing/examples/user-project/build.gradle.kts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+plugins {
+    kotlin("multiplatform") version libs.versions.kotlinVersion.get()
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+    maven("../mpp-sample/build/.m2/")
+    mavenLocal()
+}
+
+kotlin {
+    jvm()
+
+    js()
+
+    wasmJs {}
+    wasmWasi {}
+
+    macosArm64()
+    macosX64()
+    linuxArm64()
+    linuxX64()
+    mingwX64()
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(kotlin("stdlib"))
+                implementation(kotlin("test-junit"))
+                implementation("kotlinx.atomicfu.examples:mpp-sample:DUMMY_VERSION")
+            }
+        }
+        commonTest {}
+    }
+}

--- a/integration-testing/examples/user-project/gradle.properties
+++ b/integration-testing/examples/user-project/gradle.properties
@@ -1,0 +1,4 @@
+##
+## Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+##
+kotlin_version=1.9.21

--- a/integration-testing/examples/user-project/settings.gradle.kts
+++ b/integration-testing/examples/user-project/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            version("kotlinVersion", providers.gradleProperty("kotlin_version").orNull)
+        }
+    }
+}
+
+rootProject.name = "user-project"

--- a/integration-testing/examples/user-project/src/commonMain/kotlin/Sample.kt
+++ b/integration-testing/examples/user-project/src/commonMain/kotlin/Sample.kt
@@ -1,4 +1,4 @@
-import kotlinx.atomicfu.examples.mpp_sample.*
+import examples.mpp_sample.*
 import kotlin.test.*
 
 fun doWorld()  {

--- a/integration-testing/examples/user-project/src/commonMain/kotlin/Sample.kt
+++ b/integration-testing/examples/user-project/src/commonMain/kotlin/Sample.kt
@@ -1,0 +1,9 @@
+import kotlinx.atomicfu.examples.mpp_sample.*
+import kotlin.test.*
+
+fun doWorld()  {
+    val sampleClass = AtomicSampleClass()
+    sampleClass.doWork(1234)
+    assertEquals(1234, sampleClass.x)
+    assertEquals(42, sampleClass.synchronizedFoo(42))
+}

--- a/integration-testing/examples/user-project/src/commonTest/kotlin/SampleTest.kt
+++ b/integration-testing/examples/user-project/src/commonTest/kotlin/SampleTest.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import kotlin.test.*
+
+class SampleTest {
+    @Test
+    fun test() {
+        doWorld()
+    }
+}

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
@@ -53,7 +53,8 @@ class MppProjectTest {
     fun testMppNativeWithEnabledIrTransformation() {
         mppSample.enableNativeIrTransformation = true
         assertTrue(mppSample.cleanAndBuild().isSuccessful)
-        mppSample.checkMppNativeCompileOnlyDependencies()
+        // When Native IR transformations are applied, atomicfu-gradle-plugin still provides transitive atomicfu dependency
+        mppSample.checkMppNativeImplementationDependencies()
         // TODO: klib checks are skipped for now because of this problem KT-61143
         //mppSample.buildAndCheckNativeKlib()
     }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/UserProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/UserProjectTest.kt
@@ -1,0 +1,30 @@
+package kotlinx.atomicfu.gradle.plugin.test.cases
+
+import kotlinx.atomicfu.gradle.plugin.test.framework.runner.GradleBuild
+import kotlinx.atomicfu.gradle.plugin.test.framework.runner.cleanAndBuild
+import kotlinx.atomicfu.gradle.plugin.test.framework.runner.createGradleBuildFromSources
+import kotlinx.atomicfu.gradle.plugin.test.framework.runner.publishToLocalRepository
+import kotlin.test.*
+
+/**
+ * This test builds a project that depends on the library that uses atomicfu,
+ * without having a direct atomicfu dependency.
+ * 
+ * The test emulates a project that uses kotlinx.coroutines built with the current atomicfu plugin,
+ * and does not provide a direct atomicfu dependency.
+ */
+class UserProjectTest {
+    // Build mpp-sample project as the mpp library and publish it to the local repo
+    private val mppSample: GradleBuild = createGradleBuildFromSources("mpp-sample")
+    
+    private val userProject: GradleBuild = createGradleBuildFromSources("user-project")
+
+    @Test
+    fun testUserProjectBuild() {
+        mppSample.enableNativeIrTransformation = true
+        mppSample.publishToLocalRepository()
+        error(mppSample.targetDir)
+        val buildResult = userProject.cleanAndBuild()
+        assertTrue(buildResult.isSuccessful, buildResult.output)
+    }
+}

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/UserProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/UserProjectTest.kt
@@ -1,6 +1,8 @@
 package kotlinx.atomicfu.gradle.plugin.test.cases
 
+import kotlinx.atomicfu.gradle.plugin.test.framework.runner.*
 import kotlinx.atomicfu.gradle.plugin.test.framework.runner.GradleBuild
+import kotlinx.atomicfu.gradle.plugin.test.framework.runner.LOCAL_REPO_DIR_PREFIX
 import kotlinx.atomicfu.gradle.plugin.test.framework.runner.cleanAndBuild
 import kotlinx.atomicfu.gradle.plugin.test.framework.runner.createGradleBuildFromSources
 import kotlinx.atomicfu.gradle.plugin.test.framework.runner.publishToLocalRepository
@@ -23,7 +25,11 @@ class UserProjectTest {
     fun testUserProjectBuild() {
         mppSample.enableNativeIrTransformation = true
         mppSample.publishToLocalRepository()
-        error(mppSample.targetDir)
+        val mppSamplePublishDirectory = mppSample.targetDir.resolve(LOCAL_REPO_DIR_PREFIX)
+        require(mppSamplePublishDirectory.exists() && mppSamplePublishDirectory.isDirectory) {
+            "Failed to find the local repository for ${mppSample.projectName}, this directory does not exist: ${mppSamplePublishDirectory.path}"
+        }
+        userProject.localRepositoryUrl = mppSamplePublishDirectory.path
         val buildResult = userProject.cleanAndBuild()
         assertTrue(buildResult.isSuccessful, buildResult.output)
     }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
@@ -11,12 +11,16 @@ internal class GradleBuild(val projectName: String, val targetDir: File) {
     var enableJvmIrTransformation = false
     var enableJsIrTransformation = false
     var enableNativeIrTransformation = false
+    var localRepositoryUrl: String? = null
 
     private val properties
         get() = buildList {
             add("-P$ENABLE_JVM_IR_TRANSFORMATION=$enableJvmIrTransformation")
             add("-P$ENABLE_JS_IR_TRANSFORMATION=$enableJsIrTransformation")
             add("-P$ENABLE_NATIVE_IR_TRANSFORMATION=$enableNativeIrTransformation")
+            localRepositoryUrl?.let {
+                add("-P$LOCAL_REPOSITORY_URL_PROPERTY=$it")
+            }
         }
 
     private var runCount = 0

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
@@ -9,4 +9,4 @@ internal fun GradleBuild.cleanAndBuild(): BuildResult = runGradle(listOf("clean"
 internal fun GradleBuild.dependencies(): BuildResult = runGradle(listOf("dependencies"))
 
 internal fun GradleBuild.publishToLocalRepository(): BuildResult =
-    runGradle(listOf("clean", "publishMavenPublicationToLocalRepository"))
+    runGradle(listOf("clean", "publish"))

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Environment.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Environment.kt
@@ -6,12 +6,12 @@ package kotlinx.atomicfu.gradle.plugin.test.framework.runner
 
 import java.io.File
 
-internal const val ATOMICFU_VERSION = "atomicfu_version"
-internal const val KOTLIN_VERSION = "kotlin_version"
 internal const val ENABLE_JVM_IR_TRANSFORMATION = "kotlinx.atomicfu.enableJvmIrTransformation"
 internal const val ENABLE_JS_IR_TRANSFORMATION = "kotlinx.atomicfu.enableJsIrTransformation"
 internal const val ENABLE_NATIVE_IR_TRANSFORMATION = "kotlinx.atomicfu.enableNativeIrTransformation"
+internal const val LOCAL_REPOSITORY_URL_PROPERTY = "localRepositoryUrl"
 internal const val DUMMY_VERSION = "DUMMY_VERSION"
+internal const val LOCAL_REPO_DIR_PREFIX = "build/.m2/"
 
 internal val atomicfuVersion = System.getProperty("atomicfuVersion")
 
@@ -20,8 +20,8 @@ internal val gradleWrapperDir = File("..")
 internal val projectExamplesDir = File("examples")
 
 internal fun getLocalRepoDir(targetDir: File): File =
-    targetDir.resolve("build/.m2/").also {
-        require(it.exists() && it.isDirectory) { "Could not find local repository `build/.m2/` in the project directory: ${targetDir.path}" }
+    targetDir.resolve(LOCAL_REPO_DIR_PREFIX).also {
+        require(it.exists() && it.isDirectory) { "Could not find local repository `$LOCAL_REPO_DIR_PREFIX` in the project directory: ${targetDir.path}" }
     }
 
 // The project is published in the local repo directory /build/.m2/ with DUMMY_VERSION


### PR DESCRIPTION
Fixes #379


Can be tested by building integration tests in kotlinx.coroutines (https://github.com/Kotlin/kotlinx.coroutines/pull/3974).