### PR TITLE
Skip prelease check in sample projects

### DIFF
--- a/integration-testing/examples/jvm-sample/build.gradle.kts
+++ b/integration-testing/examples/jvm-sample/build.gradle.kts
@@ -33,6 +33,12 @@ dependencies {
     implementation(kotlin("test-junit"))
 }
 
+tasks.compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xskip-prerelease-check")
+    }
+}
+
 publishing {
     repositories {
         /**

--- a/integration-testing/examples/mpp-sample/build.gradle.kts
+++ b/integration-testing/examples/mpp-sample/build.gradle.kts
@@ -56,6 +56,12 @@ kotlin {
     }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xskip-prerelease-check")
+    }
+}
+
 publishing {
     repositories {
         /**


### PR DESCRIPTION
Sample projects in integration tests are built with the fixed Kotlin version, that does not depend on the Kotlin version in global gradle.properties. 
Hence in aggregate build we can get an error `Pre-release classes were found in dependencies.`.