### PR TITLE
Fix adding -Xskip-prerelease-check to integration tests

### DIFF
--- a/integration-testing/examples/mpp-sample/build.gradle.kts
+++ b/integration-testing/examples/mpp-sample/build.gradle.kts
@@ -1,6 +1,9 @@
 /*
  * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+
 buildscript {
     repositories {
         mavenLocal()
@@ -56,7 +59,7 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+tasks.withType<KotlinCompile<*>>().configureEach {
     kotlinOptions {
         freeCompilerArgs += listOf("-Xskip-prerelease-check")
     }

--- a/integration-testing/examples/user-project/build.gradle.kts
+++ b/integration-testing/examples/user-project/build.gradle.kts
@@ -1,6 +1,9 @@
 /*
  * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
+
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+
 plugins {
     kotlin("multiplatform") version libs.versions.kotlinVersion.get()
 }
@@ -41,7 +44,7 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+tasks.withType<KotlinCompile<*>>().configureEach {
     kotlinOptions {
         freeCompilerArgs += listOf("-Xskip-prerelease-check")
     }


### PR DESCRIPTION
the wrong type of `KotlinCompile` task was provided.

See the original PR: #381.