### PR TITLE
Fix mavenTest dependency: removed direct dependency to the snapshot version

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation(kotlin("script-runtime"))
 
     // mavenTest dependencies
-    "mavenTestImplementation"("org.jetbrains.kotlinx:atomicfu-jvm:$atomicfu_snapshot_version")
+    "mavenTestImplementation"(project(":atomicfu"))
 
     // functionalTest dependencies
     "functionalTestImplementation"(gradleTestKit())


### PR DESCRIPTION
`mavenTest` is supposed to check contents of `atomicfu-jvm.jar`. For that it depended on the snapshot version of atomicfu, that should've been published locally. This snapshot dependency broke community-plugin build (see https://youtrack.jetbrains.com/issue/QA-1164/Atomicfu-integration-tests-fail-with-the-community-plugin), because resolution of the snapshot version happened before the artefact was published. 

Replacement of snapshot dependency with `project(":atomicfu")` seems to solve the problem. According to the Gradle [docs](https://docs.gradle.org/current/userguide/declaring_dependencies_between_subprojects.html), `project()` should provide dependency to the artefact produced by the atomicfu project.

Fixes QA-1164