### PR TITLE
Add all sources to the transformed directory

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -337,8 +337,9 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
                 it.destinationDirectory.value(originalDestinationDirectory)
             }
         }
-        val originalClassesDirs: FileCollection =
-            project.files(classesDirs.from.toTypedArray()).filter { it.exists() }
+        val originalClassesDirs: FileCollection = 
+            project.objects.fileCollection().from(compilationTask.flatMap { it.destinationDirectory }) + 
+                project.files(classesDirs.from.toTypedArray()).filter { it.exists() }
         originalDirsByCompilation[compilation] = originalClassesDirs
         val transformedClassesDir = project.layout.buildDirectory
             .dir("classes/atomicfu/${target.name}/${compilation.name}")

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -337,9 +337,9 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
                 it.destinationDirectory.value(originalDestinationDirectory)
             }
         }
-        val originalClassesDirs: FileCollection = 
-            project.objects.fileCollection().from(compilationTask.flatMap { it.destinationDirectory }) + 
-                project.files(classesDirs.from.toTypedArray()).filter { it.exists() }
+        val originalClassesDirs: FileCollection = project.objects.fileCollection()
+            .from(compilationTask.flatMap { it.destinationDirectory })
+            .from({ project.files(classesDirs.from).filter { it.exists() } })
         originalDirsByCompilation[compilation] = originalClassesDirs
         val transformedClassesDir = project.layout.buildDirectory
             .dir("classes/atomicfu/${target.name}/${compilation.name}")

--- a/integration-testing/examples/jvm-sample/build.gradle.kts
+++ b/integration-testing/examples/jvm-sample/build.gradle.kts
@@ -14,6 +14,7 @@ group = "kotlinx.atomicfu.examples"
 version = "DUMMY_VERSION"
 
 plugins {
+    application
     kotlin("jvm") version libs.versions.kotlinVersion.get()
     `maven-publish`
 }
@@ -35,6 +36,10 @@ tasks.compileKotlin {
     kotlinOptions {
         freeCompilerArgs += listOf("-Xskip-prerelease-check")
     }
+}
+
+application {
+    mainClass.set("org.example.MainKt")
 }
 
 publishing {

--- a/integration-testing/examples/jvm-sample/src/main/java/JavaClass.java
+++ b/integration-testing/examples/jvm-sample/src/main/java/JavaClass.java
@@ -1,5 +1,3 @@
-package org.example;
-
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 public class JavaClass {


### PR DESCRIPTION
In #303 we introduced new directories: `atomicfu-orig` for original sources and `atomicfu` for transformed sources. Though only transformed Kotlin sources were placed into the `atomicfu` directory, that caused a runtime error for projects with Java sources.

In this PR I copy both Kotlin and Java sources to the transformed directory.

In the previous [commit](https://github.com/Kotlin/kotlinx-atomicfu/commit/6c7ca4b03d465f9f2ac399e9f11ef4b6a312f1d0), that was supposed to fix this error, I only added Java sources to the transformed directory.

Fixes #388