### PR TITLE
Add atomicfu to the apiElements config for native targets

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -128,9 +128,10 @@ private fun Project.configureMultiplatformPluginDependencies(version: String) {
         implementation(atomicfuDependency)
     }
     // Include atomicfu as a dependency for publication when transformation for the target is disabled
-    multiplatformExtension.targets.all { target ->
-        // Add an implementation dependency for native/wasm targets or if transformation is disabled
-        if (isTransitiveAtomicfuDependencyRequired(target)) {
+    multiplatformExtension.targets
+        .matching { target -> isTransitiveAtomicfuDependencyRequired(target) }
+        .all { target ->
+            // Add an implementation dependency for native/wasm targets or if transformation is disable
             target.compilations.all { compilation ->
                 compilation
                     .defaultSourceSet
@@ -139,9 +140,12 @@ private fun Project.configureMultiplatformPluginDependencies(version: String) {
                     }
             }
         }
-        // atomicfu should also appear in apiElements config for native targets, 
-        // otherwise the warning is triggered, see: KT-64109
-        if (target.platformType == KotlinPlatformType.native) {
+
+    // atomicfu should also appear in apiElements config for native targets, 
+    // otherwise the warning is triggered, see: KT-64109
+    multiplatformExtension.targets
+        .matching { target -> target.platformType == KotlinPlatformType.native }
+        .all { target ->
             target.compilations.all { compilation ->
                 compilation
                     .defaultSourceSet
@@ -150,7 +154,6 @@ private fun Project.configureMultiplatformPluginDependencies(version: String) {
                     }
             }
         }
-    }
 }
 
 private data class KotlinVersion(val major: Int, val minor: Int, val patch: Int)
@@ -202,6 +205,7 @@ private fun Project.isTransitiveAtomicfuDependencyRequired(target: KotlinTarget)
     return !config.transformJvm && (platformType == KotlinPlatformType.jvm || platformType == KotlinPlatformType.androidJvm) ||
             !config.transformJs && platformType == KotlinPlatformType.js ||
             platformType == KotlinPlatformType.wasm ||
+            // Always add the transitive atomicfu dependency for native targets, see #379
             platformType == KotlinPlatformType.native
 }
 


### PR DESCRIPTION
The warning about `compileOnly` dependencies declared for native sourceSets will be specified in 2.0 and will only be triggered when dependency is not present in the `apiElements` config of the native sourceSet. See [KT-64109](https://youtrack.jetbrains.com/issue/KT-64109) for more details.

The corresponding issue: #376 