### PR TITLE
Run Gradle builds of integration tests with --no-daemon option

### DIFF
--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Utils.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Utils.kt
@@ -26,9 +26,9 @@ internal fun GradleBuild.buildGradleByShell(
 
 private fun buildSystemCommand(projectDir: File, commands: List<String>, properties: List<String>): List<String> {
     return if (isWindows)
-        listOf("cmd", "/C", "gradlew.bat", "-p", projectDir.canonicalPath) + commands + properties
+        listOf("cmd", "/C", "gradlew.bat", "-p", projectDir.canonicalPath) + commands + properties + "--no-daemon"
     else
-        listOf("/bin/bash", "gradlew", "-p", projectDir.canonicalPath) + commands + properties
+        listOf("/bin/bash", "gradlew", "-p", projectDir.canonicalPath) + commands + properties + "--no-daemon"
 }
 
 private val isWindows: Boolean = System.getProperty("os.name")!!.contains("Windows")   


### PR DESCRIPTION
`kotlinx.atomicfu` builds were temporary removed from Kotlin Dev (from the aggregate build). 
The reason: atomicfu tests left a Gradle daemon running on an agent after the build was finished. 

Here is the YT ticket: https://youtrack.jetbrains.com/issue/KTI-1608/Project-kotlinx.atomicfu-tests-leak-the-Gradle-daemon-process-used-for-testing

This is how I locally reproduced the problem:
1. killed all Gradle daemons
2. ran integration tests with a `--no-daemon` option
3. saw a Gradle Daemon in jps after the tests completed their execution

Probably, running them with `--no-daemon` will help.

Another solution: I could also check the child processes of the process created with `ProcessBuilder`, and then kill the specified Gradle daemon, but I'm not sure if we need to.