### PR TITLE
ReentrantLock expect class should declare a default constructor

### DIFF
--- a/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/locks/Synchronized.common.kt
+++ b/atomicfu/src/commonMain/kotlin/kotlinx/atomicfu/locks/Synchronized.common.kt
@@ -1,10 +1,14 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.atomicfu.locks
 
 public expect open class SynchronizedObject() // marker abstract class
 
 public expect fun reentrantLock(): ReentrantLock
 
-public expect class ReentrantLock {
+public expect class ReentrantLock() {
     fun lock(): Unit
     fun tryLock(): Boolean
     fun unlock(): Unit

--- a/atomicfu/src/commonTest/kotlin/bytecode_test/ReentrantLockTest.kt
+++ b/atomicfu/src/commonTest/kotlin/bytecode_test/ReentrantLockTest.kt
@@ -1,15 +1,24 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package bytecode_test
 
 import kotlinx.atomicfu.locks.*
 import kotlin.test.*
 
 class ReentrantLockTest {
-    private val lock = reentrantLock()
+    private val lock_constructor = ReentrantLock()
+    private val lock_factory = reentrantLock()
     private var state = 0
 
     @Test
     fun testLockField() {
-        lock.withLock {
+        lock_constructor.withLock { 
+            state = 6
+        }
+        assertEquals(6, state)
+        lock_factory.withLock {
             state = 1
         }
         assertEquals(1, state)

--- a/integration-testing/examples/mpp-sample/src/commonMain/kotlin/AtomicSampleClass.kt
+++ b/integration-testing/examples/mpp-sample/src/commonMain/kotlin/AtomicSampleClass.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package examples.mpp_sample
@@ -19,9 +19,17 @@ public class AtomicSampleClass {
         assertTrue(_x.compareAndSet(3, finalValue))
     }
     
-    private val lock = reentrantLock()
+    private val lock_factory = reentrantLock()
     
-    public fun synchronizedFoo(value: Int): Int {
-        return lock.withLock { value }
+    private val lock_cons = ReentrantLock()
+    
+    private var state: Int = 0
+    
+    public fun synchronizedSetState(value: Int): Int {
+        lock_cons.withLock { state = 0 }
+        assertEquals(0, state)
+        lock_factory.withLock { state = value }
+        assertEquals(value, state)
+        return state
     }
 }

--- a/integration-testing/examples/mpp-sample/src/commonTest/kotlin/AtomicSampleTest.kt
+++ b/integration-testing/examples/mpp-sample/src/commonTest/kotlin/AtomicSampleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import kotlin.test.*
@@ -12,6 +12,6 @@ class AtomicSampleTest {
         val a = AtomicSampleClass()
         a.doWork(1234)
         assertEquals(1234, a.x)
-        assertEquals(42, a.synchronizedFoo(42))
+        assertEquals(42, a.synchronizedSetState(42))
     }
 }

--- a/integration-testing/examples/user-project/src/commonMain/kotlin/Sample.kt
+++ b/integration-testing/examples/user-project/src/commonMain/kotlin/Sample.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 import examples.mpp_sample.*
 import kotlin.test.*
 
@@ -5,5 +9,5 @@ fun doWorld()  {
     val sampleClass = AtomicSampleClass()
     sampleClass.doWork(1234)
     assertEquals(1234, sampleClass.x)
-    assertEquals(42, sampleClass.synchronizedFoo(42))
+    assertEquals(42, sampleClass.synchronizedSetState(42))
 }


### PR DESCRIPTION
Fixes #401

`ReentrantLock` constructor is a public API, though it was not covered with tests and it's direct invocation caused an error `"Expected class has no default constructor"`.