### PR TITLE
Tidy up our synchronization code

### DIFF
--- a/atomicfu/src/nativeInterop/cinterop/interop.def
+++ b/atomicfu/src/nativeInterop/cinterop/interop.def
@@ -9,11 +9,6 @@ typedef struct lock_support {
     pthread_cond_t cond;
 } lock_support_t;
 
-typedef struct mutex_node {
-    lock_support_t* mutex;
-    struct mutex_node* next;
-} mutex_node_t;
-
 lock_support_t* lock_support_init() {
     lock_support_t * ls = (lock_support_t *) malloc(sizeof(lock_support_t));
     ls->locked = 0;
@@ -21,13 +16,6 @@ lock_support_t* lock_support_init() {
     pthread_cond_init(&ls->cond, NULL);
     return ls;
 }
-
-mutex_node_t* mutex_node_init(mutex_node_t* mutexNode) {
-    mutexNode->mutex = lock_support_init();
-    mutexNode->next = NULL;
-    return mutexNode;
-}
-
 void lock(lock_support_t* ls) {
     pthread_mutex_lock(&ls->mutex);
     while (ls->locked == 1) { // wait till locked are available

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/PosixLockSupport.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/PosixLockSupport.kt
@@ -1,22 +1,21 @@
 package kotlinx.atomicfu.locks
 
+import interop.*
 import kotlinx.cinterop.*
 import platform.posix.*
 import kotlin.concurrent.*
 
 public class NativeMutexNode {
-    private val mutex: interop.mutex_node_t = nativeHeap.alloc<interop.mutex_node_t>().also {
-        interop.mutex_node_init(it.ptr)
-    }
+    private val mutex: CPointer<lock_support_t> = lock_support_init()!!
 
     internal var next: NativeMutexNode? = null
 
     fun lock() {
-        interop.lock(mutex.mutex)
+        interop.lock(mutex)
     }
 
     fun unlock() {
-        interop.unlock(mutex.mutex)
+        interop.unlock(mutex)
     }
 }
 

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/PosixLockSupport.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/PosixLockSupport.kt
@@ -1,0 +1,20 @@
+package kotlinx.atomicfu.locks
+
+import kotlinx.cinterop.*
+
+public class NativeMutexNode {
+    private val mutex: interop.mutex_node_t = nativeHeap.alloc<interop.mutex_node_t>().also {
+        interop.mutex_node_init(it.ptr)
+    }
+
+    internal var next: NativeMutexNode? = null
+
+    fun lock() {
+        interop.lock(mutex.mutex)
+    }
+
+    fun unlock() {
+        interop.unlock(mutex.mutex)
+    }
+}
+

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/PosixLockSupport.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/PosixLockSupport.kt
@@ -1,6 +1,8 @@
 package kotlinx.atomicfu.locks
 
 import kotlinx.cinterop.*
+import platform.posix.*
+import kotlin.concurrent.*
 
 public class NativeMutexNode {
     private val mutex: interop.mutex_node_t = nativeHeap.alloc<interop.mutex_node_t>().also {
@@ -18,3 +20,33 @@ public class NativeMutexNode {
     }
 }
 
+/**
+ * This is a trivial counter-part of NativeMutexNode that does not rely on interop.def
+ * The problem is, commonizer cannot commonize pthreads, thus this declaration should be duplicated
+ * over multiple Native source-sets to work properly
+ */
+//public class NativeMutexNode {
+//
+//    @Volatile
+//    private var isLocked = false
+//    private val pMutex = nativeHeap.alloc<pthread_mutex_t>().apply { pthread_mutex_init(ptr, null) }
+//    private val pCond = nativeHeap.alloc<pthread_cond_t>().apply { pthread_cond_init(ptr, null) }
+//
+//    internal var next: NativeMutexNode? = null
+//
+//    fun lock() {
+//        pthread_mutex_lock(pMutex.ptr)
+//        while (isLocked) { // wait till locked are available
+//            pthread_cond_wait(pCond.ptr, pMutex.ptr)
+//        }
+//        isLocked = true
+//        pthread_mutex_unlock(pMutex.ptr)
+//    }
+//
+//    fun unlock() {
+//        pthread_mutex_lock(pMutex.ptr)
+//        isLocked = false
+//        pthread_cond_broadcast(pCond.ptr)
+//        pthread_mutex_unlock(pMutex.ptr)
+//    }
+//}


### PR DESCRIPTION
This is a prerequisite for #412 to simplify further development and maintenance

The current state:

* No semantic changes
* All interop-related code confined to a dedicated class
* Trivial attempt to get rid of cinterop failed, I've left a few pointers (or can I say `CPointer`s?)

Further step:
* Merge this PR to base branch (`optimize-synchronized`)
* Confine/deprecate excessive public API
* Optimize and fix #412