### PR TITLE
Moved all the dependencies version to version catalog

### DIFF
--- a/atomicfu-gradle-plugin/build.gradle
+++ b/atomicfu-gradle-plugin/build.gradle
@@ -19,16 +19,16 @@ dependencies {
     }
 
     compileOnly gradleApi()
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib'
-    compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    compileOnly libs.kotlin.stdlib
+    compileOnly libs.kotlin.gradlePlugin
     // Atomicfu compiler plugin dependency will be loaded to kotlinCompilerPluginClasspath
     // Atomicfu plugin will only be applied if the flag is set kotlinx.atomicfu.enableJsIrTransformation=true
-    compileOnly "org.jetbrains.kotlin:atomicfu:$kotlin_version"
+    compileOnly libs.kotlin.atomicfu
 
     testImplementation gradleTestKit()
-    testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit'
-    testImplementation 'junit:junit:4.12'
+    testImplementation libs.kotlin.test
+    testImplementation libs.kotlin.testJunit
+    testImplementation libs.junit.junit
 }
 
 evaluationDependsOn(':atomicfu')

--- a/atomicfu-maven-plugin/build.gradle
+++ b/atomicfu-maven-plugin/build.gradle
@@ -10,11 +10,9 @@ apply from: rootProject.file('gradle/compile-options.gradle')
 ext.configureKotlin()
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compileOnly libs.kotlin.stdlib
     api project(":atomicfu-transformer")
-    api "org.apache.maven:maven-core:$maven_version"
-    api "org.apache.maven:maven-plugin-api:$maven_version"
-    api 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5'
+    api libs.bundles.maven
 }
 
 def outputDir = compileKotlin.destinationDirectory

--- a/atomicfu-transformer/build.gradle
+++ b/atomicfu-transformer/build.gradle
@@ -9,13 +9,12 @@ apply from: rootProject.file('gradle/compile-options.gradle')
 ext.configureKotlin()
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    api "org.ow2.asm:asm:$asm_version"
-    api "org.ow2.asm:asm-commons:$asm_version"
-    api "org.ow2.asm:asm-tree:$asm_version"
-    api "org.ow2.asm:asm-util:$asm_version"
-    api "org.slf4j:slf4j-api:$slf4j_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
-    api "org.mozilla:rhino:1.7.10"
-    api "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinx_metadata_version"
+    api libs.bundles.asm
+    api libs.slf4j.api
+    api libs.mozilla.rhino
+    api libs.kotlinx.metadataJvm
+
+    compileOnly libs.kotlin.stdlib
+
+    runtimeOnly libs.slf4j.simple
 }

--- a/atomicfu/build.gradle
+++ b/atomicfu/build.gradle
@@ -5,6 +5,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 apply plugin: 'kotlin-multiplatform'
+
 apply from: rootProject.file("gradle/targets.gradle")
 
 ext {
@@ -52,7 +53,7 @@ kotlin {
             dependencies {
                 implementation('org.jetbrains.kotlin:kotlin-stdlib') {
                     version {
-                        prefer "$kotlin_version"
+                        prefer libs.versions.kotlin.get()
                     }
                 }
             }
@@ -116,7 +117,7 @@ kotlin {
                 implementation 'org.jetbrains.kotlin:kotlin-reflect'
                 implementation 'org.jetbrains.kotlin:kotlin-test'
                 implementation 'org.jetbrains.kotlin:kotlin-test-junit'
-                implementation "junit:junit:$junit_version"
+                implementation libs.junit.junit
             }
         }
     }

--- a/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/Synchronized.kt
+++ b/atomicfu/src/nativeMain/kotlin/kotlinx/atomicfu/locks/Synchronized.kt
@@ -9,6 +9,7 @@ import kotlin.concurrent.AtomicNativePtr
 import kotlin.concurrent.AtomicReference
 import kotlin.native.concurrent.*
 
+@OptIn(UnsafeNumber::class) // required for KT-60572
 public actual open class SynchronizedObject {
 
     protected val lock = AtomicReference(LockState(UNLOCKED, 0, 0))

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@ import org.jetbrains.kotlin.gradle.tasks.*
 import org.jetbrains.kotlin.konan.target.HostManager
 
 buildscript {
-    def overridingKotlinVersion = KotlinConfiguration.getOverridingKotlinVersion(project)
-    if (overridingKotlinVersion != null) { project.kotlin_version = overridingKotlinVersion }
 
     /*
      * This property group is used to build kotlinx.atomicfu against Kotlin compiler snapshots.
@@ -19,10 +17,6 @@ buildscript {
     def buildSnapshotTrainGradleProperty = project.findProperty("build_snapshot_train")
     ext.build_snapshot_train = buildSnapshotTrainGradleProperty != null && buildSnapshotTrainGradleProperty != ""
     if (build_snapshot_train) {
-        project.kotlin_version = project.findProperty("kotlin_snapshot_version")
-        if (project.kotlin_version == null) {
-            throw new IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with a snapshot compiler")
-        }
         repositories {
             maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
             mavenLocal()
@@ -37,8 +31,8 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.github.node-gradle:gradle-node-plugin:$gradle_node_version"
+        classpath libs.kotlin.gradlePlugin
+        classpath libs.gradle.nodePlubing
     }
 
     ext.native_targets_enabled = !project.hasProperty("disable_native_targets")
@@ -52,17 +46,13 @@ allprojects {
     // the only place where HostManager could be instantiated
     project.ext.hostManager = new HostManager()
 
-    def overridingKotlinVersion = KotlinConfiguration.getOverridingKotlinVersion(project)
-    if (overridingKotlinVersion != null) { project.kotlin_version = overridingKotlinVersion }
-
     if (build_snapshot_train) {
-        project.kotlin_version = project.findProperty("kotlin_snapshot_version")
         repositories {
             maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         }
     }
 
-    logger.info("Using Kotlin compiler ${project.kotlin_version} for project ${project.name}")
+    logger.info("Using Kotlin compiler ${libs.versions.kotlin} for project ${project.name}")
 
     repositories {
         mavenCentral()

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,32 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+
+            val kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+            if (kotlinVersion != null) {
+                version("kotlin", kotlinVersion)
+            }
+
+            val overridingKotlinVersion =  providers.gradleProperty("community.project.kotlin.version").orNull
+            if (overridingKotlinVersion != null) {
+                logger.info("An overriding Kotlin version of $overridingKotlinVersion was found for buildSrc")
+                version("kotlin", overridingKotlinVersion)
+            }
+
+            /*
+            * This property group is used to build kotlinx.atomicfu against Kotlin compiler snapshots.
+            * When build_snapshot_train is set to true, kotlin_version property is overridden with kotlin_snapshot_version.
+            * Additionally, mavenLocal and Sonatype snapshots are added to repository list
+            * (the former is required for AFU and public, the latter is required for compiler snapshots).
+            * DO NOT change the name of these properties without adapting kotlinx.train build chain.
+            */
+            val buildSnapshotTrainGradleProperty = providers.gradleProperty("build_snapshot_train").orNull
+            if (buildSnapshotTrainGradleProperty != null && buildSnapshotTrainGradleProperty != "") {
+                val kotlinVersion = providers.gradleProperty("kotlin_snapshot_version").orNull
+                    ?: throw IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with a snapshot compiler")
+                version("kotlin", kotlinVersion)
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/KotlinConfiguration.kt
+++ b/buildSrc/src/main/kotlin/KotlinConfiguration.kt
@@ -52,24 +52,6 @@ fun addCustomKotlinRepositoryIfEnabled(repositoryHandler: RepositoryHandler, pro
 /**
  * Should be used for running against a non-released Kotlin compiler on a system test level.
  *
- * @return a Kotlin version taken from the Kotlin community project Gradle plugin,
- *         or null otherwise
- */
-fun getOverridingKotlinVersion(project: Project): String? {
-    val communityPluginKotlinVersion = project.findProperty("community.project.kotlin.version") as? String
-    // add any other ways of overriding the Kotlin version here
-    val kotlinVersion = when {
-        communityPluginKotlinVersion != null -> communityPluginKotlinVersion
-        // add any other ways of overriding the Kotlin version here
-        else -> return null
-    }
-    LOGGER.info("An overriding Kotlin version of $kotlinVersion was found for project ${project.name}")
-    return kotlinVersion
-}
-
-/**
- * Should be used for running against a non-released Kotlin compiler on a system test level.
- *
  * @return a Kotlin language version taken from:
  *
  * 1. the Kotlin community project Gradle plugin,

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,23 +5,6 @@
 version=0.24.0-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlin_version=1.9.21
-
-asm_version=9.6
-slf4j_version=1.8.0-alpha2
-junit_version=4.12
-kotlinx_metadata_version=0.7.0
-
-maven_version=3.5.3
-
-gradle_node_version=3.1.1
-node_version=8.11.1
-npm_version=5.7.1
-mocha_version=4.1.0
-mocha_headless_chrome_version=1.8.2
-mocha_teamcity_reporter_version=2.2.2
-source_map_support_version=0.5.3
-
 kotlin.native.ignoreDisabledTargets=true
 
 kotlin.mpp.enableCInteropCommonization=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,50 @@
+[versions]
+kotlin = "1.9.21"
+kotlinx-metadata = "0.7.0"
+asm = "9.6"
+slf4j = "1.8.0-alpha2"
+junit = "4.12"
+maven = "3.5.3"
+maven-pluginTools = "3.5"
+node-gradle = "3.1.1"
+node = "8.11.1"
+npm = "5.7.1"
+rhino = "1.7.10"
+
+[libraries]
+
+# Kotlin dependencies
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-atomicfu = { group = "org.jetbrains.kotlin", name = "atomicfu", version.ref = "kotlin" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlin-stdlibJdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-testJunit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
+kotlin-scriptRuntime = { group = "org.jetbrains.kotlin", name = "kotlin-script-runtime", version.ref = "kotlin" }
+kotlinx-metadataJvm = { group = "org.jetbrains.kotlinx", name = "kotlinx-metadata-jvm", version.ref = "kotlinx-metadata" }
+
+# ASM dependencies
+asm = { group = "org.ow2.asm", name = "asm", version.ref = "asm" }
+asm-commons = { group = "org.ow2.asm", name = "asm-commons", version.ref = "asm" }
+asm-tree = { group = "org.ow2.asm", name = "asm-tree", version.ref = "asm" }
+asm-util = { group = "org.ow2.asm", name = "asm-util", version.ref = "asm" }
+
+# Logging dependencies
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+
+# Testing depedencies
+junit-junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+# Maven dependencies
+maven-core = { group = "org.apache.maven", name = "maven-core", version.ref = "maven" }
+maven-pluginApi = { group = "org.apache.maven", name = "maven-plugin-api", version.ref = "maven" }
+maven-pluginAnnotations = { group = "org.apache.maven.plugin-tools", name = "maven-plugin-annotations", version.ref = "maven-pluginTools" }
+
+# Other dependencies
+gradle-nodePlubing = { group = "com.github.node-gradle", name = "gradle-node-plugin", version.ref = "node-gradle" }
+mozilla-rhino = { group = "org.mozilla", name = "rhino", version.ref = "rhino" }
+
+[bundles]
+asm = ["asm", "asm-commons", "asm-tree", "asm-util"]
+maven = ["maven-core", "maven-pluginApi", "maven-pluginAnnotations"]

--- a/gradle/node-js.gradle
+++ b/gradle/node-js.gradle
@@ -6,8 +6,8 @@ apply plugin: 'com.github.node-gradle.node'
 
 
 node {
-    version = "$node_version"
-    npmVersion = "$npm_version"
+    version = libs.versions.node
+    npmVersion = libs.versions.npm
     download = true
     nodeModulesDir = file(buildDir)
 }

--- a/gradle/publish-npm-js.gradle
+++ b/gradle/publish-npm-js.gradle
@@ -27,7 +27,7 @@ def compileJsLegacy = tasks.hasProperty("compileKotlinJsLegacy")
 
 task preparePublishNpm(type: Copy, dependsOn: [compileJsLegacy]) {
     from(npmTemplateDir) {
-        expand (project.properties + [kotlinDependency: "\"kotlin\": \"$kotlin_version\""])
+        expand (project.properties + [kotlinDependency: "\"kotlin\": \"${libs.versions.kotlin.get()}"])
     }
     from(compileJsLegacy.destinationDirectory)
     into npmDeployDir

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
     jvmToolchain(11)
 }
 
-val kotlin_version = providers.gradleProperty("kotlin_version").orNull
+val kotlin_version = providers.gradleProperty(libs.versions.kotlin).orNull
 val atomicfu_snapshot_version = providers.gradleProperty("version").orNull
 
 sourceSets {
@@ -37,33 +37,32 @@ sourceSets {
 
 dependencies {
     // common dependencies
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    testImplementation("org.jetbrains.kotlin:kotlin-test")
-    implementation("org.jetbrains.kotlin:kotlin-script-runtime")
-    implementation(kotlin("script-runtime"))
+    implementation(libs.kotlin.stdlibJdk8)
+    testImplementation(libs.kotlin.test)
+    implementation(libs.kotlin.scriptRuntime)
 
     // mavenTest dependencies
     "mavenTestImplementation"(project(":atomicfu"))
 
     // functionalTest dependencies
     "functionalTestImplementation"(gradleTestKit())
-    "functionalTestApi"("org.ow2.asm:asm:9.3")
-    "functionalTestApi"("org.ow2.asm:asm-commons:9.3")
+    "functionalTestApi"(libs.asm)
+    "functionalTestApi"(libs.asm.commons)
 }
 
 val mavenTest by tasks.registering(Test::class) {
     testClassesDirs = sourceSets["mavenTest"].output.classesDirs
     classpath = sourceSets["mavenTest"].runtimeClasspath
-    
+
     dependsOn(":atomicfu:publishToMavenLocal")
-    
+
     outputs.upToDateWhen { false }
 }
 
 val functionalTest by tasks.registering(Test::class) {
     testClassesDirs = sourceSets["functionalTest"].output.classesDirs
     classpath = sourceSets["functionalTest"].runtimeClasspath
-    
+
     systemProperties["kotlinVersion"] = kotlin_version
     systemProperties["atomicfuVersion"] = atomicfu_snapshot_version
 
@@ -71,7 +70,7 @@ val functionalTest by tasks.registering(Test::class) {
     // atomicfu-transformer and atomicfu artifacts should also be published as it's required by atomicfu-gradle-plugin.
     dependsOn(":atomicfu-transformer:publishToMavenLocal")
     dependsOn(":atomicfu:publishToMavenLocal")
-    
+
     outputs.upToDateWhen { false }
 }
 
@@ -80,7 +79,7 @@ tasks.check { dependsOn(mavenTest, functionalTest) }
 // Setup K/N infrastructure to use klib utility in tests
 // TODO: klib checks are skipped for now because of this problem KT-61143
 val Project.konanHome: String
-get() = rootProject.properties["kotlin.native.home"]?.toString()
+    get() = rootProject.properties["kotlin.native.home"]?.toString()
         ?: NativeCompilerDownloader(project).compilerDirectory.absolutePath
 
 val embeddableJar = File(project.konanHome).resolve("konan/lib/kotlin-native-compiler-embeddable.jar")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,0 @@
-include 'atomicfu'
-include 'atomicfu-transformer'
-include 'atomicfu-gradle-plugin'
-include 'atomicfu-maven-plugin'
-
-include 'atomicfu-native' // this is a kludge so that existing YouTrack config works, todo: remove
-include 'integration-testing'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,39 @@
+include("atomicfu")
+include("atomicfu-transformer")
+include("atomicfu-gradle-plugin")
+include("atomicfu-maven-plugin")
+
+include("atomicfu-native") // this is a kludge so that existing YouTrack config works, todo: remove
+include("integration-testing")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+
+            val kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+            if (kotlinVersion != null) {
+                version("kotlin", kotlinVersion)
+            }
+
+            val overridingKotlinVersion =  providers.gradleProperty("community.project.kotlin.version").orNull
+            if (overridingKotlinVersion != null) {
+                logger.info("An overriding Kotlin version of $overridingKotlinVersion was found for root `kotlinx-atomicfu`")
+                version("kotlin", overridingKotlinVersion)
+            }
+
+            /*
+            * This property group is used to build kotlinx.atomicfu against Kotlin compiler snapshots.
+            * When build_snapshot_train is set to true, kotlin_version property is overridden with kotlin_snapshot_version.
+            * Additionally, mavenLocal and Sonatype snapshots are added to repository list
+            * (the former is required for AFU and public, the latter is required for compiler snapshots).
+            * DO NOT change the name of these properties without adapting kotlinx.train build chain.
+            */
+            val buildSnapshotTrainGradleProperty = providers.gradleProperty("build_snapshot_train").orNull
+            if (buildSnapshotTrainGradleProperty != null && buildSnapshotTrainGradleProperty != "") {
+                val kotlinVersion = providers.gradleProperty("kotlin_snapshot_version").orNull
+                    ?: throw IllegalArgumentException("'kotlin_snapshot_version' should be defined when building with a snapshot compiler")
+                version("kotlin", kotlinVersion)
+            }
+        }
+    }
+}


### PR DESCRIPTION
In this PR we moved all the dependencies version in [libs.versions.toml](https://docs.gradle.org/8.4/userguide/platforms.html#sub:conventional-dependencies-toml). Such approach have several advantages:

- Gradle generates type-safe accessors for each dependency
- versions catalog is visible for all projects, so it is a single place to declare all versions