### PR TITLE
Run integration tests with Kotlin version used to build the library

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -65,7 +65,7 @@ val functionalTest by tasks.registering(Test::class) {
     classpath = sourceSets["functionalTest"].runtimeClasspath
 
     // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
-    systemProperties["kotlin.version.integration"] = libs.versions.kotlin
+    systemProperties["kotlin.version.integration"] = providers.gradleProperty("kotlin_version").orNull
     // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
     systemProperties["kotlin.native.version.integration"] = providers.gradleProperty("kotlin.native.version").orNull
     // the current atomicfu version set in the root gradle.properties

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -24,9 +24,6 @@ kotlin {
     jvmToolchain(11)
 }
 
-val kotlin_version = providers.gradleProperty(libs.versions.kotlin).orNull
-val atomicfu_snapshot_version = providers.gradleProperty("version").orNull
-
 sourceSets {
     create("mavenTest") {
         compileClasspath += files(sourceSets.main.get().output, configurations.testRuntimeClasspath)
@@ -68,7 +65,7 @@ val functionalTest by tasks.registering(Test::class) {
     classpath = sourceSets["functionalTest"].runtimeClasspath
 
     // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
-    systemProperties["kotlin.version.integration"] = providers.gradleProperty("kotlin_version").orNull
+    systemProperties["kotlin.version.integration"] = libs.versions.kotlin
     // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
     systemProperties["kotlin.native.version.integration"] = providers.gradleProperty("kotlin.native.version").orNull
     // the current atomicfu version set in the root gradle.properties

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -72,7 +72,7 @@ val functionalTest by tasks.registering(Test::class) {
     // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
     systemProperties["kotlin.native.version.integration"] = providers.gradleProperty("kotlin.native.version").orNull
     // the current atomicfu version set in the root gradle.properties
-    systemProperties["atomicfu.version.integration"] = providers.gradleProperty("version").orNull
+    systemProperties["atomicfu.snapshot.version.integration"] = providers.gradleProperty("version").orNull
     // the directory (on TC agent) where Kotlin artifacts were published during the Aggregate build
     systemProperties["kotlin.artifacts.repository.integration"] = providers.gradleProperty("kotlin_repo_url").orNull
 

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 import org.jetbrains.kotlin.gradle.utils.NativeCompilerDownloader
 
 plugins {
@@ -63,8 +67,14 @@ val functionalTest by tasks.registering(Test::class) {
     testClassesDirs = sourceSets["functionalTest"].output.classesDirs
     classpath = sourceSets["functionalTest"].runtimeClasspath
 
-    systemProperties["kotlinVersion"] = kotlin_version
-    systemProperties["atomicfuVersion"] = atomicfu_snapshot_version
+    // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
+    systemProperties["kotlin.version.integration"] = providers.gradleProperty("kotlin_version").orNull
+    // the kotlin version used to build the library, which is set in root gradle.properties or overriden by the TC config
+    systemProperties["kotlin.native.version.integration"] = providers.gradleProperty("kotlin.native.version").orNull
+    // the current atomicfu version set in the root gradle.properties
+    systemProperties["atomicfu.version.integration"] = providers.gradleProperty("version").orNull
+    // the directory (on TC agent) where Kotlin artifacts were published during the Aggregate build
+    systemProperties["kotlin.artifacts.repository.integration"] = providers.gradleProperty("kotlin_repo_url").orNull
 
     dependsOn(":atomicfu-gradle-plugin:publishToMavenLocal")
     // atomicfu-transformer and atomicfu artifacts should also be published as it's required by atomicfu-gradle-plugin.

--- a/integration-testing/examples/mpp-sample/build.gradle.kts
+++ b/integration-testing/examples/mpp-sample/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
@@ -34,12 +34,12 @@ repositories {
 
 kotlin {
     jvm()
-    
+
     js()
-    
+
     wasmJs {}
     wasmWasi {}
-    
+
     macosArm64()
     macosX64()
     linuxArm64()
@@ -50,7 +50,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("test-junit"))
+                implementation(kotlin("test"))
             }
         }
         commonTest {}

--- a/integration-testing/examples/mpp-version-catalog/settings.gradle.kts
+++ b/integration-testing/examples/mpp-version-catalog/settings.gradle.kts
@@ -1,13 +1,17 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 rootProject.name = "mpp-version-catalog"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
     repositories {
-        
         google()
         gradlePluginPortal()
         mavenCentral()
         mavenLocal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     }
 }
 
@@ -16,6 +20,18 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         mavenLocal()
+    }
+    versionCatalogs {
+        create("libs") {
+            val atomicfuVersion = providers.gradleProperty("atomicfu_version").orNull
+            if (atomicfuVersion != null) {
+                version("atomicfu", atomicfuVersion)
+            }
+            val kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+            if (kotlinVersion != null) {
+                version("kotlin", kotlinVersion)
+            }
+        }
     }
 }
 

--- a/integration-testing/examples/mpp-version-catalog/shared/build.gradle.kts
+++ b/integration-testing/examples/mpp-version-catalog/shared/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 
 buildscript {
@@ -8,6 +12,7 @@ buildscript {
 
 repositories {
     mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     mavenLocal()
 }
 
@@ -28,12 +33,12 @@ kotlin {
     linuxArm64()
     linuxX64()
     mingwX64()
-    
+
     sourceSets {
         commonMain{
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("test-junit"))
+                implementation(kotlin("test"))
             }
         }
     }

--- a/integration-testing/examples/plugin-order-bug/build.gradle
+++ b/integration-testing/examples/plugin-order-bug/build.gradle
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 
 buildscript {
@@ -39,7 +43,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("test-junit"))
+                implementation(kotlin("test"))
             }
         }
         commonTest {}

--- a/integration-testing/examples/user-project/build.gradle.kts
+++ b/integration-testing/examples/user-project/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
@@ -13,7 +13,7 @@ repositories {
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
     val localRepositoryUrl = findProperty("localRepositoryUrl")
     if (localRepositoryUrl != null) {
-        maven(localRepositoryUrl)   
+        maven(localRepositoryUrl)
     }
     mavenLocal()
 }
@@ -36,7 +36,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("test-junit"))
+                implementation(kotlin("test"))
                 implementation("kotlinx.atomicfu.examples:mpp-sample:DUMMY_VERSION")
             }
         }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package test
@@ -31,20 +31,20 @@ class MppProjectTest {
     @Test
     fun testMppWithEnabledJsIrTransformation() {
         mppSample.enableJsIrTransformation = true
-        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.cleanAndBuild()
         mppSample.checkConsumableDependencies()
     }
 
     @Test
     fun testMppWithDisabledJsIrTransformation() {
         mppSample.enableJsIrTransformation = false
-        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.cleanAndBuild()
         mppSample.checkConsumableDependencies()
     }
-    
+
     @Test
     fun testMppWasmBuild() {
-        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.cleanAndBuild()
         mppSample.checkMppWasmJsImplementationDependencies()
         mppSample.checkMppWasmWasiImplementationDependencies()
     }
@@ -52,7 +52,7 @@ class MppProjectTest {
     @Test
     fun testMppNativeWithEnabledIrTransformation() {
         mppSample.enableNativeIrTransformation = true
-        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.cleanAndBuild()
         // When Native IR transformations are applied, atomicfu-gradle-plugin still provides transitive atomicfu dependency
         mppSample.checkMppNativeImplementationDependencies()
         // TODO: klib checks are skipped for now because of this problem KT-61143
@@ -62,7 +62,7 @@ class MppProjectTest {
     @Test
     fun testMppNativeWithDisabledIrTransformation() {
         mppSample.enableNativeIrTransformation = false
-        assertTrue(mppSample.cleanAndBuild().isSuccessful)
+        mppSample.cleanAndBuild()
         mppSample.checkMppNativeImplementationDependencies()
         // TODO: klib checks are skipped for now because of this problem KT-61143
         //mppSample.buildAndCheckNativeKlib()

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppVersionCatalogTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppVersionCatalogTest.kt
@@ -14,8 +14,7 @@ class MppVersionCatalogTest {
     fun testBuildWithKotlinNewerThan_1_9_0() {
         mppWithVersionCatalog.enableJvmIrTransformation = true
         mppWithVersionCatalog.enableNativeIrTransformation = true
-        val buildResult = mppWithVersionCatalog.cleanAndBuild()
-        assertTrue(buildResult.isSuccessful, buildResult.output)
+        mppWithVersionCatalog.cleanAndBuild()
         mppWithVersionCatalog.buildAndCheckBytecode()
     }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MultiModuleTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MultiModuleTest.kt
@@ -15,16 +15,14 @@ class MultiModuleTest {
     @Test
     fun testMppWithDisabledJvmIrTransformation() {
         multiModuleTest.enableJvmIrTransformation = false
-        val buildResult = multiModuleTest.cleanAndBuild()
-        assertTrue(buildResult.isSuccessful, buildResult.output)
+        multiModuleTest.cleanAndBuild()
         multiModuleTest.buildAndCheckBytecode()
     }
 
     @Test
     fun testMppWithEnabledJvmIrTransformation() {
         multiModuleTest.enableJvmIrTransformation = true
-        val buildResult = multiModuleTest.cleanAndBuild()
-        assertTrue(buildResult.isSuccessful, buildResult.output)
+        multiModuleTest.cleanAndBuild()
         multiModuleTest.buildAndCheckBytecode()
     }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/PluginOrderBugTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/PluginOrderBugTest.kt
@@ -14,22 +14,24 @@ class PluginOrderBugTest {
 
     @Test
     fun testUserProjectBuild() {
-        val buildResult = pluginOrderBugProject.cleanAndBuild()
-        assertTrue(buildResult.isSuccessful, buildResult.output)
+        pluginOrderBugProject.cleanAndBuild()
     }
 
     /**
-     * kotlin-stdlib is an implementation dependency of :atomicfu module, 
+     * kotlin-stdlib is an implementation dependency of :atomicfu module,
      * because compileOnly dependencies are not applicable for Native targets (#376).
-     * 
-     * This test ensures that kotlin-stdlib of the Kotlin version used to build kotlinx-atomicfu library is not "required" in the user's project.
+     *
+     * This test sets Kotlin version in `plugin-order-bug` project that differs from the Kotlin version set for the library.
+     * The goal is to check that kotlin-stdlib of the Kotlin version used to build kotlinx-atomicfu library is not "required" in the user's project.
      * The user project should use kotlin-stdlib version that is present in it's classpath.
      */
     @Test
     fun testTransitiveKotlinStdlibDependency() {
+        pluginOrderBugProject.extraProperties.add("-Pkotlin_version=1.9.20")
+        assertTrue(pluginOrderBugProject.getKotlinVersion() == "1.9.20")
         val dependencies = pluginOrderBugProject.dependencies()
-        assertFalse(dependencies.output.contains("org.jetbrains.kotlin:kotlin-stdlib:{strictly $libraryKotlinVersion}"), 
-            "Strict requirement for 'org.jetbrains.kotlin:kotlin-stdlib:{strictly $libraryKotlinVersion}' was found in the project ${pluginOrderBugProject.projectName} dependencies, " +
+        assertFalse(dependencies.output.contains("org.jetbrains.kotlin:kotlin-stdlib:{strictly $kotlinVersion}"),
+            "Strict requirement for 'org.jetbrains.kotlin:kotlin-stdlib:{strictly $kotlinVersion}' was found in the project ${pluginOrderBugProject.projectName} dependencies, " +
                     "while Kotlin version used in the project is ${pluginOrderBugProject.getKotlinVersion()}"
         )
     }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/UserProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/UserProjectTest.kt
@@ -30,7 +30,6 @@ class UserProjectTest {
             "Failed to find the local repository for ${mppSample.projectName}, this directory does not exist: ${mppSamplePublishDirectory.path}"
         }
         userProject.localRepositoryUrl = mppSamplePublishDirectory.path
-        val buildResult = userProject.cleanAndBuild()
-        assertTrue(buildResult.isSuccessful, buildResult.output)
+        userProject.cleanAndBuild()
     }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/ArtifactChecker.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/ArtifactChecker.kt
@@ -124,14 +124,12 @@ private class KlibChecker(targetDir: File) : ArtifactChecker(targetDir) {
 }
 
 internal fun GradleBuild.buildAndCheckBytecode() {
-    val buildResult = cleanAndBuild()
-    require(buildResult.isSuccessful) { "Build of the project $projectName failed:\n ${buildResult.output}" }
+    cleanAndBuild()
     BytecodeChecker(this).checkClassesInBuildDirectories()
 }
 
 // TODO: klib checks are skipped for now because of this problem KT-61143
 internal fun GradleBuild.buildAndCheckNativeKlib() {
-    val buildResult = cleanAndBuild()
-    require(buildResult.isSuccessful) { "Build of the project $projectName failed:\n ${buildResult.output}" }
+    cleanAndBuild()
     KlibChecker(this.targetDir).checkClassesInBuildDirectories()
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
@@ -21,8 +21,8 @@ internal class GradleBuild(val projectName: String, val targetDir: File) {
             add("-P$ENABLE_NATIVE_IR_TRANSFORMATION=$enableNativeIrTransformation")
             // Pass kotlin_version and kotlin.native.version parameters used for the library build to the builds of integration tests.
             // These versions may be overriden by the TC build config.
-            kotlinVersion?.let { add("-P$KOTLIN_VERSION_PARAMETER=$it") }
-            kotlinNativeVersion?.let { add("-P$KOTLIN_NATIVE_VERSION_PARAMETER=$it") }
+            if (kotlinVersion.isNotEmpty()) add("-P$KOTLIN_VERSION_PARAMETER=$kotlinVersion")
+            if (kotlinNativeVersion.isNotEmpty()) add("-P$KOTLIN_NATIVE_VERSION_PARAMETER=$kotlinNativeVersion")
             localRepositoryUrl?.let { add("-P$LOCAL_REPOSITORY_URL_PROPERTY=$it") }
             addAll(extraProperties)
         }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.atomicfu.gradle.plugin.test.framework.runner
@@ -19,9 +19,11 @@ internal class GradleBuild(val projectName: String, val targetDir: File) {
             add("-P$ENABLE_JVM_IR_TRANSFORMATION=$enableJvmIrTransformation")
             add("-P$ENABLE_JS_IR_TRANSFORMATION=$enableJsIrTransformation")
             add("-P$ENABLE_NATIVE_IR_TRANSFORMATION=$enableNativeIrTransformation")
-            localRepositoryUrl?.let {
-                add("-P$LOCAL_REPOSITORY_URL_PROPERTY=$it")
-            }
+            // Pass kotlin_version and kotlin.native.version parameters used for the library build to the builds of integration tests.
+            // These versions may be overriden by the TC build config.
+            kotlinVersion?.let { add("-P$KOTLIN_VERSION_PARAMETER=$it") }
+            kotlinNativeVersion?.let { add("-P$KOTLIN_NATIVE_VERSION_PARAMETER=$it") }
+            localRepositoryUrl?.let { add("-P$LOCAL_REPOSITORY_URL_PROPERTY=$it") }
             addAll(extraProperties)
         }
 
@@ -59,6 +61,15 @@ internal fun createGradleBuildFromSources(projectName: String): GradleBuild {
     val projectDir = projectExamplesDir.resolve(projectName)
     val targetDir = Files.createTempDirectory("${projectName.substringAfterLast('/')}-").toFile().apply {
         projectDir.copyRecursively(this)
+    }
+    kotlinArtifactsRepo?.let {
+        // kotlinArtifactsRepo contains the directory on the TC agent, where Kotlin artifacts were published
+        // (this directory was passed as kotlin_repo_url parameter to the library build).
+
+        // Add maven(url =  file:///mnt/agent/work/...) repository in build.gradle and settings.gradle files of all integration tests.
+        targetDir.walkTopDown().filter { it.isFile && (it.name.startsWith("build.gradle") || it.name.startsWith("settings.gradle")) }.forEach { buildGradleFile ->
+            buildGradleFile.addKotlinArtifactRepositoryToProjectBuild(kotlinArtifactsRepo)
+        }
     }
     return GradleBuild(projectName, targetDir)
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildScriptConfigurator.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildScriptConfigurator.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.atomicfu.gradle.plugin.test.framework.runner
+
+import java.io.*
+
+/**
+ * This function adds a given repository to the repositories {} blocks declared in build files:
+ * // settings.gradle:
+ * pluginManagement {
+ *   repositories {
+ *      maven(url = "file:///mnt/agent/work/../artifacts/kotlin")
+ *      mavenCentral()
+ *   }
+ * }
+ *
+ * // build.gradle:
+ * repositories {
+ *   maven(url = "file:///mnt/agent/work/../artifacts/kotlin")
+ * }
+ */
+internal fun File.addKotlinArtifactRepositoryToProjectBuild(
+    repository: String
+) {
+    val isKts = name.endsWith(".kts")
+    val originLines = readLines()
+    var previousLine = ""
+
+    bufferedWriter().use { writer ->
+        originLines.forEach { line ->
+            writer.appendLine(line)
+            // in build.gradle exclude publishing { repositories {...} } block
+            val isInPublishingBlock = previousLine.trimStart().startsWith("publishing")
+            // in settings.gradle add repository only in pluginManagement {...} block
+            val isInPluginManagementBlock = line.trimStart().startsWith("pluginManagement")
+            val isRepositoryBlock = line.trimStart().startsWith("repositories")
+            if (line.isNotBlank() && ((isInPluginManagementBlock && isRepositoryBlock) || (!isInPublishingBlock && isRepositoryBlock))) {
+                if (isKts) {
+                    writer.appendLine("maven(url = \"$repository\")")
+                } else {
+                    writer.appendLine("maven { url '$repository' }")
+                }
+            }
+            previousLine = line
+        }
+    }
+}

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildScriptConfigurator.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildScriptConfigurator.kt
@@ -34,7 +34,7 @@ internal fun File.addKotlinArtifactRepositoryToProjectBuild(
             // in build.gradle exclude publishing { repositories {...} } block
             val isInPublishingBlock = previousLine.trimStart().startsWith("publishing")
             // in settings.gradle add repository only in pluginManagement {...} block
-            val isInPluginManagementBlock = line.trimStart().startsWith("pluginManagement")
+            val isInPluginManagementBlock = previousLine.trimStart().startsWith("pluginManagement")
             val isRepositoryBlock = line.trimStart().startsWith("repositories")
             if (line.isNotBlank() && ((isInPluginManagementBlock && isRepositoryBlock) || (!isInPublishingBlock && isRepositoryBlock))) {
                 if (isKts) {

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
@@ -6,7 +6,10 @@ package kotlinx.atomicfu.gradle.plugin.test.framework.runner
 
 import kotlinx.atomicfu.gradle.plugin.test.framework.checker.getProjectClasspath
 
-internal fun GradleBuild.cleanAndBuild(): BuildResult = runGradle(listOf("clean", "build"))
+internal fun GradleBuild.cleanAndBuild(): BuildResult =
+    runGradle(listOf("clean", "build")).also {
+        require(it.isSuccessful) { "${this.projectName}:build task FAILED: ${it.output} " }
+    }
 
 internal fun GradleBuild.cleanAndJar(): BuildResult = runGradle(listOf("clean", "jar"))
 

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Environment.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Environment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.atomicfu.gradle.plugin.test.framework.runner
@@ -10,12 +10,15 @@ internal const val ENABLE_JVM_IR_TRANSFORMATION = "kotlinx.atomicfu.enableJvmIrT
 internal const val ENABLE_JS_IR_TRANSFORMATION = "kotlinx.atomicfu.enableJsIrTransformation"
 internal const val ENABLE_NATIVE_IR_TRANSFORMATION = "kotlinx.atomicfu.enableNativeIrTransformation"
 internal const val LOCAL_REPOSITORY_URL_PROPERTY = "localRepositoryUrl"
-internal const val KOTLIN_VERSION_PROPERTY = "localRepositoryUrl"
+internal const val KOTLIN_VERSION_PARAMETER = "kotlin_version"
+internal const val KOTLIN_NATIVE_VERSION_PARAMETER = "kotlin.native.version"
 internal const val DUMMY_VERSION = "DUMMY_VERSION"
 internal const val LOCAL_REPO_DIR_PREFIX = "build/.m2/"
 
-internal val libraryKotlinVersion = System.getProperty("kotlinVersion")
-internal val atomicfuVersion = System.getProperty("atomicfuVersion")
+internal val kotlinVersion = System.getProperty("kotlin.version.integration")
+internal val kotlinNativeVersion = System.getProperty("kotlin.native.version.integration")
+internal val atomicfuVersion = System.getProperty("atomicfu.version.integration")
+internal val kotlinArtifactsRepo = System.getProperty("kotlin.artifacts.repository.integration")
 
 internal val gradleWrapperDir = File("..")
 

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Environment.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Environment.kt
@@ -17,7 +17,7 @@ internal const val LOCAL_REPO_DIR_PREFIX = "build/.m2/"
 
 internal val kotlinVersion = System.getProperty("kotlin.version.integration")
 internal val kotlinNativeVersion = System.getProperty("kotlin.native.version.integration")
-internal val atomicfuVersion = System.getProperty("atomicfu.version.integration")
+internal val atomicfuVersion = System.getProperty("atomicfu.snapshot.version.integration")
 internal val kotlinArtifactsRepo = System.getProperty("kotlin.artifacts.repository.integration")
 
 internal val gradleWrapperDir = File("..")

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Utils.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.atomicfu.gradle.plugin.test.framework.runner


### PR DESCRIPTION
Fixes #419

The main goal of this PR is to test builds of projects from `integration-testing` against the Kotlin version used to build the library. E.g. in Aggregate build test projects should be built with Kotlin from master branch. Otherwise with the same Kotlin version that is set in the root `gradle.properties` file.

Previously Kotlin version for all integration tests was hardcoded in their local `gradle.properties` files.

