### PR TITLE
Extended integration tests configurations with implementation conf

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -26,13 +26,29 @@ kotlin {
 
 sourceSets {
     create("mavenTest") {
-        compileClasspath += files(sourceSets.main.get().output, configurations.testRuntimeClasspath)
-        runtimeClasspath += output + compileClasspath
+        compileClasspath += sourceSets.main.get().output
+        runtimeClasspath += sourceSets.main.get().output
+
+        configurations.getByName(implementationConfigurationName) {
+            extendsFrom(configurations.getByName(sourceSets.main.get().implementationConfigurationName))
+            extendsFrom(configurations.getByName(sourceSets.test.get().implementationConfigurationName))
+        }
     }
 
     create("functionalTest") {
-        compileClasspath += files(sourceSets.main.get().output, configurations.testRuntimeClasspath)
-        runtimeClasspath += output + compileClasspath
+        compileClasspath += sourceSets.main.get().output
+        runtimeClasspath += sourceSets.main.get().output
+
+        configurations.getByName(implementationConfigurationName) {
+            extendsFrom(configurations.getByName(sourceSets.main.get().implementationConfigurationName))
+            extendsFrom(configurations.getByName(sourceSets.test.get().implementationConfigurationName))
+        }
+
+        configurations.getByName(runtimeOnlyConfigurationName) {
+            extendsFrom(configurations.getByName(sourceSets.main.get().runtimeOnlyConfigurationName))
+            extendsFrom(configurations.getByName(sourceSets.test.get().runtimeOnlyConfigurationName))
+        }
+
     }
 }
 


### PR DESCRIPTION
Updated integration test configurations according to [gradle docs](https://docs.gradle.org/current/userguide/java_testing.html#sec:configuring_java_integration_tests).
It helps to IJ IDEA better resolve test source and run tests using IJ IDEA gutters