### PR TITLE
Fix the new ID of the atomicfu-gradle-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,28 +112,53 @@ operations. They can be also atomically modified via `+=` and `-=` operators.
 ### Apply plugin
 #### Gradle configuration
 
-In top-level build file:
+> **New plugin id:** Please pay attention, that starting from version `0.25.0` the plugin id is `org.jetbrains.kotlinx.atomicfu`
+
+Add the following to your top-level build file:
 
 <details open>
-<summary>Kotlin DSL</summary>
+<summary>Kotlin</summary>
+
+```kotlin
+plugins {
+     id("org.jetbrains.kotlinx.atomicfu") version "0.25.0"
+}
+```
+</details>
+
+<details open>
+<summary>Groovy</summary>
+
+```groovy
+plugins {
+    id 'org.jetbrains.kotlinx.atomicfu' version '0.25.0'
+}
+```
+</details>
+
+
+#### Legacy plugin application
+
+<details open>
+<summary>Kotlin</summary>
 
 ```kotlin
 buildscript {
-    repositories {
-        mavenCentral()
-    }
+  repositories {
+    mavenCentral()
+  }
 
-    dependencies {
-      classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.24.0")
-    }
+  dependencies {
+    classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.24.0")
+  }
 }
 
-apply(plugin = "kotlinx-atomicfu")
+apply(plugin = "org.jetbrains.kotlinx.atomicfu")
 ```
 </details>
 
 <details>
-<summary>Groovy DSL</summary>
+<summary>Groovy</summary>
 
 ```groovy
 buildscript {
@@ -145,7 +170,7 @@ buildscript {
     }
 }
   
-apply plugin: 'kotlinx-atomicfu'
+apply plugin: 'org.jetbrains.kotlinx.atomicfu'
 ```
 </details>
 

--- a/atomicfu-gradle-plugin/build.gradle.kts
+++ b/atomicfu-gradle-plugin/build.gradle.kts
@@ -53,10 +53,11 @@ gradlePlugin {
 
     plugins {
         create("Atomicfu") {
-            id = "kotlinx-atomicfu"
+            id = "org.jetbrains.kotlinx.atomicfu"
             implementationClass = "kotlinx.atomicfu.plugin.gradle.AtomicFUGradlePlugin"
             displayName = "Gradle plugin for kotlinx-atomicfu library"
             description = "Enables efficient use of atomic operations in Kotlin multiplatform projects."
+            tags = setOf("kotlinx-atomicfu", "atomics", "kotlin")
         }
     }
 }

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicfuKotlinCompilerPluginInternal.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicfuKotlinCompilerPluginInternal.kt
@@ -33,7 +33,7 @@ internal class AtomicfuKotlinCompilerPluginInternal : KotlinCompilerPluginSuppor
         kotlinCompilation: KotlinCompilation<*>
     ): Provider<List<SubpluginOption>> = kotlinCompilation.target.project.provider { emptyList() }
 
-    override fun getCompilerPluginId() = "org.jetbrains.kotlinx.atomicfu"
+    override fun getCompilerPluginId() = "org.jetbrains.kotlin.atomicfu"
 
     // Gets "org.jetbrains.kotlin:kotlin-atomicfu-compiler-plugin-embeddable:{KGP version}"
     override fun getPluginArtifact(): SubpluginArtifact {

--- a/integration-testing/examples/jdk-compatibility/build.gradle.kts
+++ b/integration-testing/examples/jdk-compatibility/build.gradle.kts
@@ -5,7 +5,7 @@ version = "DUMMY_VERSION"
 
 plugins {
     kotlin("jvm") version libs.versions.kotlinVersion.get()
-    id("kotlinx-atomicfu") version libs.versions.atomicfuVersion.get()
+    id("org.jetbrains.kotlinx.atomicfu") version libs.versions.atomicfuVersion.get()
     `maven-publish`
 }
 

--- a/integration-testing/examples/jvm-sample/build.gradle.kts
+++ b/integration-testing/examples/jvm-sample/build.gradle.kts
@@ -4,7 +4,7 @@ version = "DUMMY_VERSION"
 plugins {
     application
     kotlin("jvm") version libs.versions.kotlinVersion.get()
-    id("kotlinx-atomicfu") version libs.versions.atomicfuVersion.get()
+    id("org.jetbrains.kotlinx.atomicfu") version libs.versions.atomicfuVersion.get()
     `maven-publish`
 }
 

--- a/integration-testing/examples/jvm-sample/build.gradle.kts
+++ b/integration-testing/examples/jvm-sample/build.gradle.kts
@@ -8,8 +8,6 @@ plugins {
     `maven-publish`
 }
 
-apply(plugin = "kotlinx-atomicfu")
-
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")

--- a/integration-testing/examples/mpp-sample/build.gradle.kts
+++ b/integration-testing/examples/mpp-sample/build.gradle.kts
@@ -10,7 +10,7 @@ version = "DUMMY_VERSION"
 plugins {
     kotlin("multiplatform") version libs.versions.kotlinVersion.get()
     `maven-publish`
-    id("kotlinx-atomicfu") version libs.versions.atomicfuVersion.get()
+    id("org.jetbrains.kotlinx.atomicfu") version libs.versions.atomicfuVersion.get()
 }
 
 repositories {

--- a/integration-testing/examples/mpp-version-catalog/shared/build.gradle.kts
+++ b/integration-testing/examples/mpp-version-catalog/shared/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    id("kotlinx-atomicfu") version libs.versions.atomicfu.get()
+    id("org.jetbrains.kotlinx.atomicfu") version libs.versions.atomicfu.get()
 }
 
 kotlin {

--- a/integration-testing/examples/multi-module-test/producer/build.gradle.kts
+++ b/integration-testing/examples/multi-module-test/producer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("multiplatform") version libs.versions.kotlinVersion.get()
-    id("kotlinx-atomicfu") version libs.versions.atomicfuVersion.get()
+    id("org.jetbrains.kotlinx.atomicfu") version libs.versions.atomicfuVersion.get()
 }
 
 repositories {

--- a/integration-testing/examples/plugin-order-bug/build.gradle
+++ b/integration-testing/examples/plugin-order-bug/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 // Apply KGP via buildscript to check this issue: #384
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'kotlinx-atomicfu'
+apply plugin: 'org.jetbrains.kotlinx.atomicfu'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
To be published on GPP the gradle plugin should be namespaced and the plugin cannot be published with the old id `kotlinx-atomicfu` as it was before. So, the plugin name is changed to `org.jetbrains.kotlinx.atomicfu`. 

And here is how the plugin should be applied now: 

```
plugins {
     id("org.jetbrains.kotlinx.atomicfu") version "0.25.0"
}
```