### PR TITLE
De-duplicated the version override in the actual project and in buildSrc

### DIFF
--- a/build-settings-logic/src/main/kotlin/atomicfu-dependency-resolution-management.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/atomicfu-dependency-resolution-management.settings.gradle.kts
@@ -1,0 +1,79 @@
+import org.gradle.kotlin.dsl.maven
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+
+        val additionalRepositoryProperty = providers.gradleProperty("kotlin_repo_url")
+        if (additionalRepositoryProperty.isPresent) {
+            maven(additionalRepositoryProperty.get()) {
+                name = "KotlinDevRepo"
+            }
+            logger.info("A custom Kotlin repository ${additionalRepositoryProperty.get()} was added")
+        }
+
+        maven("https://oss.sonatype.org/content/repositories/snapshots") {
+            mavenContent { snapshotsOnly() }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+
+    @Suppress("UnstableApiUsage")
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+
+    @Suppress("UnstableApiUsage")
+    repositories {
+        maven("https://oss.sonatype.org/content/repositories/snapshots") {
+            mavenContent { snapshotsOnly() }
+        }
+
+        val additionalRepositoryProperty = providers.gradleProperty("kotlin_repo_url")
+        if (additionalRepositoryProperty.isPresent) {
+            maven(additionalRepositoryProperty.get()) {
+                name = "KotlinDevRepo"
+            }
+            logger.info("A custom Kotlin repository ${additionalRepositoryProperty.get()} was added")
+        }
+
+        mavenCentral()
+
+
+        // we have such a task https://youtrack.jetbrains.com/issue/KT-34732 to move these artifacts to the Maven repository,
+        // but before that we need to have ivy for yarn and node dependencies
+        exclusiveContent {
+            forRepository {
+                ivy("https://nodejs.org/dist") {
+                    name = "NodeJS repository"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
+                    metadataSources { artifact() }
+                    content { includeModule("org.nodejs", "node") }
+                }
+            }
+            filter { includeGroup("org.nodejs") }
+        }
+
+        exclusiveContent {
+            forRepository {
+                ivy("https://github.com/yarnpkg/yarn/releases/download") {
+                    name = "Yarn release repository"
+                    patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
+                    metadataSources { artifact() }
+                    content { includeModule("com.yarnpkg", "yarn") }
+                }
+            }
+            filter { includeGroup("com.yarnpkg") }
+        }
+    }
+
+    versionCatalogs {
+        register("libs").configure {
+            val kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+            if (kotlinVersion != null) {
+                version("kotlin", kotlinVersion)
+            }
+        }
+    }
+}

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Utils.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Utils.kt
@@ -40,7 +40,7 @@ internal fun Path.enableCacheRedirector() {
             .normalize()
             .toFile()
 
-    val gradleDir = resolve("gradle").also { it.createDirectories() }
+    val gradleDir = resolve("gradle").createDirectories()
     redirectorScript.copyTo(gradleDir.resolve("cache-redirector.settings.gradle.kts").toFile())
 
     val settingsGradle = resolve("settings.gradle")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,94 +2,10 @@ rootProject.name = "kotlinx-atomicfu"
 
 pluginManagement {
     includeBuild("build-settings-logic")
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-
-        val additionalRepositoryProperty = providers.gradleProperty("kotlin_repo_url")
-        if (additionalRepositoryProperty.isPresent) {
-            maven(url = uri(additionalRepositoryProperty.get()))
-            logger.info("A custom Kotlin repository ${additionalRepositoryProperty.get()} was added")
-        }
-
-        /*
-         * This property group is used to build kotlinx.atomicfu against Kotlin compiler snapshots.
-         * When build_snapshot_train is set to true, mavenLocal and Sonatype snapshots are added to repository list
-         * (the former is required for AFU and public, the latter is required for compiler snapshots).
-         * DO NOT change the name of these properties without adapting kotlinx.train build chain.
-         */
-        val buildSnapshotTrainGradleProperty = providers.gradleProperty("build_snapshot_train")
-        if (buildSnapshotTrainGradleProperty.isPresent) {
-            maven(url = uri("https://oss.sonatype.org/content/repositories/snapshots"))
-        }
-    }
-}
-
-dependencyResolutionManagement {
-
-    @Suppress("UnstableApiUsage")
-    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-
-    @Suppress("UnstableApiUsage")
-    repositories {
-
-        /*
-        * This property group is used to build kotlinx.atomicfu against Kotlin compiler snapshots.
-        * When build_snapshot_train is set to true, mavenLocal and Sonatype snapshots are added to repository list
-        * (the former is required for AFU and public, the latter is required for compiler snapshots).
-        * DO NOT change the name of these properties without adapting kotlinx.train build chain.
-        */
-        val buildSnapshotTrainGradleProperty = providers.gradleProperty("build_snapshot_train")
-        if (buildSnapshotTrainGradleProperty.isPresent) {
-            maven(url = uri("https://oss.sonatype.org/content/repositories/snapshots"))
-        }
-
-        val additionalRepositoryProperty = providers.gradleProperty("kotlin_repo_url")
-        if (additionalRepositoryProperty.isPresent) {
-            maven(url = uri(additionalRepositoryProperty.get()))
-            logger.info("A custom Kotlin repository ${additionalRepositoryProperty.get()} was added")
-        }
-
-        mavenCentral()
-
-        // we have such a task https://youtrack.jetbrains.com/issue/KT-34732 to move these artifacts to the Maven repository,
-        // but before that we need to have ivy for yarn and node dependencies
-        exclusiveContent {
-            forRepository {
-                ivy("https://nodejs.org/dist") {
-                    patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
-                    metadataSources { artifact() }
-                    content { includeModule("org.nodejs", "node") }
-                }
-            }
-            filter { includeGroup("org.nodejs") }
-        }
-
-        exclusiveContent {
-            forRepository {
-                ivy("https://github.com/yarnpkg/yarn/releases/download") {
-                    patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
-                    metadataSources { artifact() }
-                    content { includeModule("com.yarnpkg", "yarn") }
-                }
-            }
-            filter { includeGroup("com.yarnpkg") }
-        }
-
-    }
-
-    versionCatalogs {
-        create("libs") {
-
-            val kotlinVersion = providers.gradleProperty("kotlin_version").orNull
-            if (kotlinVersion != null) {
-                version("kotlin", kotlinVersion)
-            }
-        }
-    }
 }
 
 plugins {
+    id("atomicfu-dependency-resolution-management")
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
     id("atomicfu-gradle-build-scan")
     id("atomicfu-gradle-build-cache")


### PR DESCRIPTION
This PR adds common settings plugin to: 
- root `settings.gradle.kts` 
- buildSrc `settings.gradle.kts` 

It removes duplicated logic by setting custom Kotlin version and custom repository URL. (`kotlin_version`, `kotlin_repo_url`, `build_snapshot_train`).

Should be checked after https://github.com/Kotlin/kotlinx-atomicfu/pull/453.