### PR TITLE
Update the convention to use Develocity token for both Scans and BuildCache

### DIFF
--- a/build-settings-logic/src/main/kotlin/atomicfu-gradle-build-cache.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/atomicfu-gradle-build-cache.settings.gradle.kts
@@ -39,12 +39,6 @@ val buildCachePushEnabled: Provider<Boolean> =
     atomicfuProperty("build.cache.push", String::toBoolean)
         .orElse(buildingOnTeamCity)
 
-val buildCacheUser: Provider<String> =
-    providers.gradleProperty("build.cache.user")
-
-val buildCachePassword: Provider<String> =
-    providers.gradleProperty("build.cache.password")
-
 buildCache {
     local {
         isEnabled = buildCacheLocalEnabled.get()
@@ -52,15 +46,7 @@ buildCache {
             directory = buildCacheLocalDirectory.get()
         }
     }
-    remote<HttpBuildCache> {
-        url = uri("https://ge.jetbrains.com/cache/")
+    remote(develocity.buildCache) {
         isPush = buildCachePushEnabled.get()
-
-        if (buildCacheUser.isPresent &&
-            buildCachePassword.isPresent
-        ) {
-            credentials.username = buildCacheUser.get()
-            credentials.password = buildCachePassword.get()
-        }
     }
 }

--- a/build-settings-logic/src/main/kotlin/atomicfu-gradle-build-scan.settings.gradle.kts
+++ b/build-settings-logic/src/main/kotlin/atomicfu-gradle-build-scan.settings.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 develocity {
     if (buildScanEnabled.get()) {
         val overriddenName = buildScanUsername.orNull
+        server = "https://ge.jetbrains.com/"
         buildScan {
-            server = "https://ge.jetbrains.com/"
             publishing.onlyIf { true }
             capture {
                 fileFingerprints = true


### PR DESCRIPTION
We want to use the Develocity token for auth for Scans, and at the same time we'll benefit from [Develocity Connector](https://docs.gradle.com/develocity/gradle-plugin/current/#using_the_develocity_connector) to get rid of BuildCache user and password (it will use the same token as the scan)
