### PR TITLE
Fix wrong test setup

### DIFF
--- a/integration-testing/examples/multi-module-test/build.gradle.kts
+++ b/integration-testing/examples/multi-module-test/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    kotlin("multiplatform") version libs.versions.kotlinVersion.get() apply false
+}

--- a/integration-testing/examples/multi-module-test/consumer/build.gradle.kts
+++ b/integration-testing/examples/multi-module-test/consumer/build.gradle.kts
@@ -5,7 +5,7 @@
  */
 
 plugins {
-    kotlin("multiplatform") version libs.versions.kotlinVersion.get()
+    kotlin("multiplatform")
     application
 }
 

--- a/integration-testing/examples/multi-module-test/producer/build.gradle.kts
+++ b/integration-testing/examples/multi-module-test/producer/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version libs.versions.kotlinVersion.get()
+    kotlin("multiplatform")
     id("org.jetbrains.kotlinx.atomicfu") version libs.versions.atomicfuVersion.get()
 }
 


### PR DESCRIPTION
Test project was applying Kotlin KMP plugin in subprojects, but not in the root 'build.gradle.kts' which is wrong from KMP point of view as it introduces Gradle classpath isolation problem.