### PR TITLE
Run Gradle plugin compilation via fixated Kotlin compiler version

### DIFF
--- a/atomicfu-gradle-plugin/build.gradle.kts
+++ b/atomicfu-gradle-plugin/build.gradle.kts
@@ -6,14 +6,7 @@ plugins {
     alias(libs.plugins.gradle.pluginPublish)
     id("kotlin-jvm-conventions")
     id("java-gradle-plugin")
-}
-
-// Gradle plugin must be compiled targeting the same Kotlin version as used by Gradle
-kotlin.sourceSets.configureEach {
-    languageSettings {
-        languageVersion = getOverridingKotlinLanguageVersion(project) ?: "1.4"
-        apiVersion = getOverridingKotlinApiVersion(project) ?: "1.4"
-    }
+    id("gradle-compatibility")
 }
 
 dependencies {

--- a/atomicfu-gradle-plugin/gradle.properties
+++ b/atomicfu-gradle-plugin/gradle.properties
@@ -1,0 +1,3 @@
+# to use fixated compiler for compiling Gradle plugin
+# configuration via project.extra is working since 2.1.0
+kotlin.compiler.runViaBuildToolsApi=true

--- a/atomicfu-transformer/api/atomicfu-transformer.api
+++ b/atomicfu-transformer/api/atomicfu-transformer.api
@@ -190,7 +190,6 @@ public final class kotlinx/atomicfu/transformer/JvmVariant : java/lang/Enum {
 	public static final field BOTH Lkotlinx/atomicfu/transformer/JvmVariant;
 	public static final field FU Lkotlinx/atomicfu/transformer/JvmVariant;
 	public static final field VH Lkotlinx/atomicfu/transformer/JvmVariant;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lkotlinx/atomicfu/transformer/JvmVariant;
 	public static fun values ()[Lkotlinx/atomicfu/transformer/JvmVariant;
 }

--- a/atomicfu-transformer/build.gradle.kts
+++ b/atomicfu-transformer/build.gradle.kts
@@ -4,6 +4,7 @@
 
 plugins {
     id("kotlin-jvm-publish-conventions")
+    id("gradle-compatibility")
 }
 
 dependencies {

--- a/atomicfu-transformer/gradle.properties
+++ b/atomicfu-transformer/gradle.properties
@@ -1,0 +1,3 @@
+# to use fixated compiler for compiling Gradle plugin
+# configuration via project.extra is working since 2.1.0
+kotlin.compiler.runViaBuildToolsApi=true

--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
         commonMain.dependencies {
             implementation("org.jetbrains.kotlin:kotlin-stdlib") {
                 version {
-                    prefer(libs.versions.kotlin.get())
+                    prefer(libs.versions.kotlin.asProvider().get())
                 }
             }
         }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.gradlePlugin)
+    compileOnly(libs.kotlin.build.tools.api) // runtime dependency of KGP
 }

--- a/buildSrc/src/main/kotlin/gradle-compatibility.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradle-compatibility.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+plugins {
+    kotlin("jvm")
+}
+
+project.extra["kotlin.compiler.runViaBuildToolsApi"] = "true"
+
+kotlin {
+    @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
+    compilerVersion.set(
+        versionCatalogs
+            .named("libs")
+            .findVersion("kotlin-for-gradle-plugin")
+            .get()
+            .requiredVersion
+    )
+
+    // Gradle plugin must be compiled targeting the same Kotlin version as used by Gradle
+    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+    compilerOptions {
+        languageVersion = getOverridingKotlinLanguageVersion(project)?.let { KotlinVersion.fromVersion(it) }
+            ?: KotlinVersion.KOTLIN_1_4
+        apiVersion = getOverridingKotlinApiVersion(project)?.let { KotlinVersion.fromVersion(it) }
+            ?: KotlinVersion.KOTLIN_1_4
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "2.0.0"
+kotlin-for-gradle-plugin = "2.0.0" # Kotlin 2.1 removes support for the used language version / api version: KT-60521
 kotlinx-binaryCompatibilityValidator = "0.16.0"
 asm = "9.7"
 slf4j = "1.8.0-alpha2"
@@ -15,6 +16,7 @@ gradle-develocity = "3.17.5"
 
 # Kotlin dependencies
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-build-tools-api = { group = "org.jetbrains.kotlin", name = "kotlin-build-tools-api", version.ref = "kotlin" }
 kotlin-atomicfu = { group = "org.jetbrains.kotlin", name = "atomicfu", version.ref = "kotlin" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlibJdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }


### PR DESCRIPTION
This also changes LV/AV of :atomicfu-transformer as it is as a runtime dependency of the plugin and contributes to compatibility with Gradle. In future, it's preferred to get rid of the dependency and use it through isolated classpath and Gradle Workers API. 

Relates to KT-60521