### PR TITLE
Update ASM to 9.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.0"
 kotlinx-binaryCompatibilityValidator = "0.16.0"
-asm = "9.6"
+asm = "9.7"
 slf4j = "1.8.0-alpha2"
 junit = "4.12"
 maven = "3.5.3"


### PR DESCRIPTION
ASM 9.7 supports Java 23 bytecode.

This is needed in order to support JVM target bytecode version 23 in Kotlin compiler (KT-71537), because there's an integration test at `integration-testing/examples/jdk-compatibility` which uses ASM with the latest supported JvmTarget version.