### PR TITLE
Fix jvm target validation error

### DIFF
--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(8)
 
     // JS -- always
     js(IR) {
@@ -201,12 +202,6 @@ val classesPreAtomicFuDir = file("${layout.buildDirectory.get()}/classes/kotlin/
 val classesPostTransformFU = file("${layout.buildDirectory.get()}/classes/kotlin/jvm/postTransformedFU")
 val classesPostTransformVH = file("${layout.buildDirectory.get()}/classes/kotlin/jvm/postTransformedVH")
 val classesPostTransformBOTH = file("${layout.buildDirectory.get()}/classes/kotlin/jvm/postTransformedBOTH")
-
-tasks.withType<KotlinCompile>().configureEach {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
-    }
-}
 
 val transformFU by tasks.registering(JavaExec::class) {
     dependsOn(tasks.get("compileTestKotlinJvm"))


### PR DESCRIPTION
 Upcoming changes in Kotlin Gradle Plugin introduce JavaCompile tasks to the KMP/JVM target. This will lead to JVM target validation error when Kotlin JVM compile task will have different JVM target from JavaCompile task.
    
  To avoid this - switched configuring JVM target to the JVM toolchain configuration, which also configures JavaCompile tasks.
