### PR TITLE
Build warnings as errors

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -15,7 +15,6 @@ import org.gradle.api.tasks.testing.*
 import org.gradle.jvm.tasks.*
 import org.gradle.util.*
 import org.jetbrains.kotlin.gradle.dsl.*
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.tasks.*
 import java.io.*
@@ -267,7 +266,7 @@ private fun Project.withKotlinTargets(fn: (KotlinTarget) -> Unit) {
     }
 }
 
-private fun KotlinCompile<*>.setFriendPaths(friendPathsFileCollection: FileCollection) {
+private fun KotlinCompilationTask<*>.setFriendPaths(friendPathsFileCollection: FileCollection) {
     val (majorVersion, minorVersion) = project.getKotlinPluginVersion()
         .split('.')
         .take(2)
@@ -393,8 +392,9 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
                 (tasks.findByName("${target.name}${compilation.name.capitalizeCompat()}") as? Test)?.classpath =
                     newClasspath
             }
+            compilation.compileTaskProvider.configure {
+                it.setFriendPaths(originalMainClassesDirs)
             }
-            compilation.compileKotlinTask.setFriendPaths(originalMainClassesDirs)
         }
     }
 }

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -384,9 +384,15 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
                     originalMainClassesDirs + compilation.compileDependencyFiles
                 )
             if (transformTask != null) {
+                val runtimeDependencyFiles = compilation.runtimeDependencyFiles
+                val newClasspath = if (runtimeDependencyFiles != null)
+                    originalMainClassesDirs + runtimeDependencyFiles - mainCompilation.output.classesDirs
+                else
+                    originalMainClassesDirs - mainCompilation.output.classesDirs
                 // if transform task was not created, then originalMainClassesDirs == mainCompilation.output.classesDirs
-                (tasks.findByName("${target.name}${compilation.name.capitalize()}") as? Test)?.classpath =
-                    originalMainClassesDirs + (compilation as KotlinCompilationToRunnableFiles).runtimeDependencyFiles - mainCompilation.output.classesDirs
+                (tasks.findByName("${target.name}${compilation.name.capitalizeCompat()}") as? Test)?.classpath =
+                    newClasspath
+            }
             }
             compilation.compileKotlinTask.setFriendPaths(originalMainClassesDirs)
         }

--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.tasks.*
 import java.io.*
 import java.util.*
+import java.util.Locale
 import javax.inject.Inject
 
 private const val EXTENSION_NAME = "atomicfu"
@@ -399,11 +400,15 @@ private fun Project.configureTransformationForTarget(target: KotlinTarget) {
     }
 }
 
-private fun String.toJvmVariant(): JvmVariant = enumValueOf(toUpperCase(Locale.US))
+private fun String.toJvmVariant(): JvmVariant = enumValueOf(uppercase(Locale.US))
+
+private fun String.capitalizeCompat() = replaceFirstChar {
+    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+}
 
 private fun Project.registerJvmTransformTask(compilation: KotlinCompilation<*>): TaskProvider<AtomicFUTransformTask> =
     tasks.register(
-        "transform${compilation.target.name.capitalize()}${compilation.name.capitalize()}Atomicfu",
+        "transform${compilation.target.name.capitalizeCompat()}${compilation.name.capitalizeCompat()}Atomicfu",
         AtomicFUTransformTask::class.java
     )
 

--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/AtomicFUTransformer.kt
@@ -158,8 +158,8 @@ class FieldInfo(
             return if (hasExternalAccess) mangleInternal(fuName) else fuName
         }
 
-    val refVolatileClassName = "${owner.replace('.', '/')}$${name.capitalize()}RefVolatile"
-    val staticRefVolatileField = refVolatileClassName.substringAfterLast("/").decapitalize()
+    val refVolatileClassName = "${owner.replace('.', '/')}$${name.capitalizeCompat()}RefVolatile"
+    val staticRefVolatileField = refVolatileClassName.substringAfterLast("/").decapitalizeCompat()
 
     fun getPrimitiveType(vh: Boolean): Type = if (vh) typeInfo.originalType else typeInfo.transformedType
 
@@ -1530,6 +1530,12 @@ class AtomicFUTransformer(
         }
 }
 
+private fun String.capitalizeCompat() = replaceFirstChar {
+    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+}
+
+private fun String.decapitalizeCompat() = replaceFirstChar { it.lowercase(Locale.getDefault()) }
+
 fun main(args: Array<String>) {
     if (args.size !in 1..3) {
         println("Usage: AtomicFUTransformerKt <dir> [<output>] [<variant>]")
@@ -1537,7 +1543,7 @@ fun main(args: Array<String>) {
     }
     val t = AtomicFUTransformer(emptyList(), File(args[0]))
     if (args.size > 1) t.outputDir = File(args[1])
-    if (args.size > 2) t.jvmVariant = enumValueOf(args[2].toUpperCase(Locale.US))
+    if (args.size > 2) t.jvmVariant = enumValueOf(args[2].uppercase(Locale.US))
     t.verbose = true
     t.transform()
 }

--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/FlowAnalyzer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/FlowAnalyzer.kt
@@ -311,7 +311,7 @@ class FlowAnalyzer(
         when (desc[0]) {
             '(' -> {
                 val types = Type.getArgumentTypes(desc)
-                pop(types.indices.sumBy { types[it].size }, forward)
+                pop(types.indices.sumOf { types[it].size }, forward)
             }
             'J', 'D' -> pop(2, forward)
             else -> pop(1, forward)

--- a/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/MetadataTransformer.kt
+++ b/atomicfu-transformer/src/main/kotlin/kotlinx/atomicfu/transformer/MetadataTransformer.kt
@@ -42,7 +42,7 @@ class MetadataTransformer(
             is KotlinClassMetadata.FileFacade -> {
                 val kmPackage = kotlinClassMetadata.kmPackage
                 KotlinClassMetadata.FileFacade(
-                    kmPackage.removeAtomicfuDeclarations() as KmPackage,
+                    kmPackage.removeAtomicfuDeclarations(),
                     metadataVersion,
                     metadata.extraInt
                 ).write()
@@ -51,7 +51,7 @@ class MetadataTransformer(
             is KotlinClassMetadata.MultiFileClassPart -> {
                 val kmPackage = kotlinClassMetadata.kmPackage
                 KotlinClassMetadata.MultiFileClassPart(
-                    kmPackage.removeAtomicfuDeclarations() as KmPackage,
+                    kmPackage.removeAtomicfuDeclarations(),
                     metadata.extraString,
                     metadataVersion,
                     metadata.extraInt

--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -1,8 +1,6 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {

--- a/build-settings-logic/build.gradle.kts
+++ b/build-settings-logic/build.gradle.kts
@@ -5,3 +5,7 @@ plugins {
 dependencies {
     implementation(libs.gradle.develocity)
 }
+
+kotlin {
+    compilerOptions.allWarningsAsErrors = true
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,3 +6,7 @@ dependencies {
     implementation(libs.kotlin.gradlePlugin)
     compileOnly(libs.kotlin.build.tools.api) // runtime dependency of KGP
 }
+
+kotlin {
+    compilerOptions.allWarningsAsErrors = true
+}

--- a/buildSrc/src/main/kotlin/gradle-compatibility.gradle.kts
+++ b/buildSrc/src/main/kotlin/gradle-compatibility.gradle.kts
@@ -21,6 +21,9 @@ kotlin {
     // Gradle plugin must be compiled targeting the same Kotlin version as used by Gradle
     @Suppress("DEPRECATION", "DEPRECATION_ERROR")
     compilerOptions {
+        allWarningsAsErrors.set(true)
+        freeCompilerArgs.add("-Xsuppress-version-warnings")
+
         languageVersion = getOverridingKotlinLanguageVersion(project)?.let { KotlinVersion.fromVersion(it) }
             ?: KotlinVersion.KOTLIN_1_6
         apiVersion = getOverridingKotlinApiVersion(project)?.let { KotlinVersion.fromVersion(it) }

--- a/buildSrc/src/main/kotlin/kotlin-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-base-conventions.gradle.kts
@@ -17,6 +17,10 @@ kotlin.sourceSets.configureEach {
             apiVersion = overridingKotlinApiVersion
         }
 
-        optIn("kotlinx.cinterop.ExperimentalForeignApi")
+        if (project.path != ":atomicfu-transformer" &&
+            project.path != ":atomicfu-gradle-plugin"
+        ) {
+            optIn("kotlinx.cinterop.ExperimentalForeignApi")
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=2g
 
 org.gradle.caching=true
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Temporarily disabled, for details see: #483
 org.gradle.configuration-cache=true


### PR DESCRIPTION
I've enabled warning-as-errors mode in build scripts and Gradle plugin compilation to avoid usages of deprecated methods.