### PR TITLE
Suppress K/JS configuration deprecation warnings

### DIFF
--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
 
     // JS -- always
     js(IR) {
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         moduleName = "kotlinx-atomicfu"
         // TODO: commented out because browser tests do not work on TeamCity
         // browser()


### PR DESCRIPTION
Relates to KT-68597, KT-75144

A PR to `develop` fixing this will be created later after migration to 2.1.20