### PR TITLE
Suppress K/JS configuration deprecation warnings in buildscript

### DIFF
--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
 
     // JS -- always
     js(IR) {
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         moduleName = "kotlinx-atomicfu"
         // TODO: commented out because browser tests do not work on TeamCity
         // browser()


### PR DESCRIPTION
This symbol is deprecated in Kotlin 2.1.20 with warning level and raised to error in 2.2.0. To be migrated to the new API after updating Kotlin to 2.1.20

Relates to KT-68597, KT-75144