### PR TITLE
Use SPDX identifier in POMs

### DIFF
--- a/buildSrc/src/main/kotlin/base-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/base-publish-conventions.gradle.kts
@@ -24,7 +24,7 @@ publishing {
 
             licenses {
                 license {
-                    name = "The Apache Software License, Version 2.0"
+                    name = "Apache-2.0"
                     url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
                     distribution = "repo"
                 }


### PR DESCRIPTION
This replaces the custom name with an SPDX identifier to enable tooling to automatically detect the correct license. Using an SPDX identifier is recommended [by the official Maven documentation](https://maven.apache.org/pom.html#Licenses).

See https://spdx.org/licenses/Apache-2.0.html