### PR TITLE
Speedup integration tests

### DIFF
--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -107,4 +107,9 @@ tasks.withType<Test> {
     // Pass the path to the cache redirector
     val cacheRedirectorPath = project.file("../build-settings-logic/src/main/kotlin/atomicfu-cache-redirector.settings.gradle.kts")
     systemProperty("cache.redirector.path", cacheRedirectorPath.absolutePath)
+
+    val forks = project.providers.gradleProperty("testing.max.forks").orNull?.toInt()
+        ?: (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+
+    maxParallelForks = forks
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/JvmProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/JvmProjectTest.kt
@@ -19,7 +19,7 @@ class JvmProjectTest {
             jvmCheckAtomicfuInCompileClasspath()
             jvmCheckNoAtomicfuInRuntimeConfigs()
         }
-        jvmSample.checkConsumableDependencies()
+        jvmSample.checkConsumableDependencies(false)
         jvmSample.buildAndCheckBytecode()
     }
 
@@ -30,7 +30,7 @@ class JvmProjectTest {
             jvmCheckAtomicfuInCompileClasspath()
             jvmCheckNoAtomicfuInRuntimeConfigs()
         }
-        jvmSample.checkConsumableDependencies()
+        jvmSample.checkConsumableDependencies(false)
         jvmSample.buildAndCheckBytecode()
     }
     

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/JvmProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/JvmProjectTest.kt
@@ -15,8 +15,10 @@ class JvmProjectTest {
     @Test
     fun testJvmWithEnabledIrTransformation() {
         jvmSample.enableJvmIrTransformation = true
-        jvmSample.jvmCheckAtomicfuInCompileClasspath()
-        jvmSample.jvmCheckNoAtomicfuInRuntimeConfigs()
+        jvmSample.withDependencies {
+            jvmCheckAtomicfuInCompileClasspath()
+            jvmCheckNoAtomicfuInRuntimeConfigs()
+        }
         jvmSample.checkConsumableDependencies()
         jvmSample.buildAndCheckBytecode()
     }
@@ -24,8 +26,10 @@ class JvmProjectTest {
     @Test
     fun testJvmWithDisabledIrTransformation() {
         jvmSample.enableJvmIrTransformation = false
-        jvmSample.jvmCheckAtomicfuInCompileClasspath()
-        jvmSample.jvmCheckNoAtomicfuInRuntimeConfigs()
+        jvmSample.withDependencies {
+            jvmCheckAtomicfuInCompileClasspath()
+            jvmCheckNoAtomicfuInRuntimeConfigs()
+        }
         jvmSample.checkConsumableDependencies()
         jvmSample.buildAndCheckBytecode()
     }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
@@ -18,7 +18,7 @@ class MppProjectTest {
             mppCheckAtomicfuInCompileClasspath("jvm")
             mppCheckNoAtomicfuInRuntimeConfigs("jvm")
         }
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(false)
         mppSample.buildAndCheckBytecode()
     }
 
@@ -29,7 +29,7 @@ class MppProjectTest {
             mppCheckAtomicfuInCompileClasspath("jvm")
             mppCheckNoAtomicfuInRuntimeConfigs("jvm")
         }
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(false)
         mppSample.buildAndCheckBytecode()
     }
 
@@ -37,23 +37,20 @@ class MppProjectTest {
     @Test
     fun testMppWithEnabledJsIrTransformation() {
         mppSample.enableJsIrTransformation = true
-        mppSample.cleanAndBuild()
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(true)
         mppSample.withDependencies { mppCheckAtomicfuInApi("js") }
     }
 
     @Test
     fun testMppWithDisabledJsIrTransformation() {
         mppSample.enableJsIrTransformation = false
-        mppSample.cleanAndBuild()
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(true)
         mppSample.withDependencies { mppCheckAtomicfuInApi("js") }
     }
 
     @Test
     fun testMppWasmJsBuild() {
-        mppSample.cleanAndBuild()
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(true)
         mppSample.withDependencies {
             mppCheckAtomicfuInCompileClasspath("wasmJs")
             mppCheckAtomicfuInRuntimeClasspath("wasmJs")
@@ -63,7 +60,7 @@ class MppProjectTest {
 
     @Test
     fun testMppWasmWasiBuild() {
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(false)
         mppSample.withDependencies {
             mppCheckAtomicfuInCompileClasspath("wasmWasi")
             mppCheckAtomicfuInRuntimeClasspath("wasmWasi")
@@ -74,9 +71,8 @@ class MppProjectTest {
     @Test
     fun testMppNativeWithEnabledIrTransformation() {
         mppSample.enableNativeIrTransformation = true
-        mppSample.cleanAndBuild()
         // When Native IR transformations are applied, atomicfu-gradle-plugin still provides transitive atomicfu dependency
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(true)
         mppSample.withDependencies {
             mppNativeCheckAtomicfuInImplementation("macosX64")
             mppCheckAtomicfuInApi("macosX64")
@@ -88,8 +84,7 @@ class MppProjectTest {
     @Test
     fun testMppNativeWithDisabledIrTransformation() {
         mppSample.enableNativeIrTransformation = false
-        mppSample.cleanAndBuild()
-        mppSample.checkConsumableDependencies()
+        mppSample.checkConsumableDependencies(true)
         mppSample.withDependencies {
             mppNativeCheckAtomicfuInImplementation("macosX64")
             mppCheckAtomicfuInApi("macosX64")

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
@@ -14,8 +14,10 @@ class MppProjectTest {
     @Test
     fun testMppWithEnabledJvmIrTransformation() {
         mppSample.enableJvmIrTransformation = true
-        mppSample.mppCheckAtomicfuInCompileClasspath("jvm")
-        mppSample.mppCheckNoAtomicfuInRuntimeConfigs("jvm")
+        mppSample.withDependencies {
+            mppCheckAtomicfuInCompileClasspath("jvm")
+            mppCheckNoAtomicfuInRuntimeConfigs("jvm")
+        }
         mppSample.checkConsumableDependencies()
         mppSample.buildAndCheckBytecode()
     }
@@ -23,8 +25,10 @@ class MppProjectTest {
     @Test
     fun testMppWithDisabledJvmIrTransformation() {
         mppSample.enableJvmIrTransformation = false
-        mppSample.mppCheckAtomicfuInCompileClasspath("jvm")
-        mppSample.mppCheckNoAtomicfuInRuntimeConfigs("jvm")
+        mppSample.withDependencies {
+            mppCheckAtomicfuInCompileClasspath("jvm")
+            mppCheckNoAtomicfuInRuntimeConfigs("jvm")
+        }
         mppSample.checkConsumableDependencies()
         mppSample.buildAndCheckBytecode()
     }
@@ -35,7 +39,7 @@ class MppProjectTest {
         mppSample.enableJsIrTransformation = true
         mppSample.cleanAndBuild()
         mppSample.checkConsumableDependencies()
-        mppSample.mppCheckAtomicfuInApi("js")
+        mppSample.withDependencies { mppCheckAtomicfuInApi("js") }
     }
 
     @Test
@@ -43,24 +47,28 @@ class MppProjectTest {
         mppSample.enableJsIrTransformation = false
         mppSample.cleanAndBuild()
         mppSample.checkConsumableDependencies()
-        mppSample.mppCheckAtomicfuInApi("js")
+        mppSample.withDependencies { mppCheckAtomicfuInApi("js") }
     }
 
     @Test
     fun testMppWasmJsBuild() {
         mppSample.cleanAndBuild()
-        mppSample.mppCheckAtomicfuInCompileClasspath("wasmJs")
-        mppSample.mppCheckAtomicfuInRuntimeClasspath("wasmJs")
         mppSample.checkConsumableDependencies()
-        mppSample.mppCheckAtomicfuInApi("wasmJs")
+        mppSample.withDependencies {
+            mppCheckAtomicfuInCompileClasspath("wasmJs")
+            mppCheckAtomicfuInRuntimeClasspath("wasmJs")
+            mppCheckAtomicfuInApi("wasmJs")
+        }
     }
 
     @Test
     fun testMppWasmWasiBuild() {
-        mppSample.mppCheckAtomicfuInCompileClasspath("wasmWasi")
-        mppSample.mppCheckAtomicfuInRuntimeClasspath("wasmWasi")
         mppSample.checkConsumableDependencies()
-        mppSample.mppCheckAtomicfuInApi("wasmWasi")
+        mppSample.withDependencies {
+            mppCheckAtomicfuInCompileClasspath("wasmWasi")
+            mppCheckAtomicfuInRuntimeClasspath("wasmWasi")
+            mppCheckAtomicfuInApi("wasmWasi")
+        }
     }
 
     @Test
@@ -68,9 +76,11 @@ class MppProjectTest {
         mppSample.enableNativeIrTransformation = true
         mppSample.cleanAndBuild()
         // When Native IR transformations are applied, atomicfu-gradle-plugin still provides transitive atomicfu dependency
-        mppSample.mppNativeCheckAtomicfuInImplementation("macosX64")
         mppSample.checkConsumableDependencies()
-        mppSample.mppCheckAtomicfuInApi("macosX64")
+        mppSample.withDependencies {
+            mppNativeCheckAtomicfuInImplementation("macosX64")
+            mppCheckAtomicfuInApi("macosX64")
+        }
         // TODO: klib checks are skipped for now because of this problem KT-61143
         //mppSample.buildAndCheckNativeKlib()
     }
@@ -79,9 +89,11 @@ class MppProjectTest {
     fun testMppNativeWithDisabledIrTransformation() {
         mppSample.enableNativeIrTransformation = false
         mppSample.cleanAndBuild()
-        mppSample.mppNativeCheckAtomicfuInImplementation("macosX64")
         mppSample.checkConsumableDependencies()
-        mppSample.mppCheckAtomicfuInApi("macosX64")
+        mppSample.withDependencies {
+            mppNativeCheckAtomicfuInImplementation("macosX64")
+            mppCheckAtomicfuInApi("macosX64")
+        }
         // TODO: klib checks are skipped for now because of this problem KT-61143
         //mppSample.buildAndCheckNativeKlib()
     }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppProjectTest.kt
@@ -8,9 +8,11 @@ import kotlinx.atomicfu.gradle.plugin.test.framework.checker.*
 import kotlinx.atomicfu.gradle.plugin.test.framework.runner.*
 import kotlin.test.*
 
-class MppProjectTest {
-    private val mppSample: GradleBuild = createGradleBuildFromSources("mpp-sample")
+abstract class MppProjectTest {
+    internal val mppSample: GradleBuild = createGradleBuildFromSources("mpp-sample")
+}
 
+class JvmMppProjectTest : MppProjectTest() {
     @Test
     fun testMppWithEnabledJvmIrTransformation() {
         mppSample.enableJvmIrTransformation = true
@@ -32,7 +34,9 @@ class MppProjectTest {
         mppSample.checkConsumableDependencies(false)
         mppSample.buildAndCheckBytecode()
     }
+}
 
+class JsMppProjectTest : MppProjectTest() {
     // TODO: JS klib will be checked for kotlinx.atomicfu references when this issue KT-61143 is fixed.
     @Test
     fun testMppWithEnabledJsIrTransformation() {
@@ -47,7 +51,9 @@ class MppProjectTest {
         mppSample.checkConsumableDependencies(true)
         mppSample.withDependencies { mppCheckAtomicfuInApi("js") }
     }
+}
 
+class WasmMppProjectTest : MppProjectTest() {
     @Test
     fun testMppWasmJsBuild() {
         mppSample.checkConsumableDependencies(true)
@@ -67,7 +73,9 @@ class MppProjectTest {
             mppCheckAtomicfuInApi("wasmWasi")
         }
     }
+}
 
+class NativeMppProjectTest : MppProjectTest() {
     @Test
     fun testMppNativeWithEnabledIrTransformation() {
         mppSample.enableNativeIrTransformation = true

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppVersionCatalogTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MppVersionCatalogTest.kt
@@ -14,7 +14,6 @@ class MppVersionCatalogTest {
     fun testBuildWithKotlinNewerThan_1_9_0() {
         mppWithVersionCatalog.enableJvmIrTransformation = true
         mppWithVersionCatalog.enableNativeIrTransformation = true
-        mppWithVersionCatalog.cleanAndBuild()
         mppWithVersionCatalog.buildAndCheckBytecode()
     }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MultiModuleTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/MultiModuleTest.kt
@@ -15,14 +15,12 @@ class MultiModuleTest {
     @Test
     fun testMppWithDisabledJvmIrTransformation() {
         multiModuleTest.enableJvmIrTransformation = false
-        multiModuleTest.cleanAndBuild()
         multiModuleTest.buildAndCheckBytecode()
     }
 
     @Test
     fun testMppWithEnabledJvmIrTransformation() {
         multiModuleTest.enableJvmIrTransformation = true
-        multiModuleTest.cleanAndBuild()
         multiModuleTest.buildAndCheckBytecode()
     }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/PluginOrderBugTest.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/cases/PluginOrderBugTest.kt
@@ -28,11 +28,12 @@ class PluginOrderBugTest {
     @Test
     fun testTransitiveKotlinStdlibDependency() {
         pluginOrderBugProject.extraProperties.add("-Pkotlin_version=1.9.20")
-        assertTrue(pluginOrderBugProject.getKotlinVersion() == "1.9.20")
+        val projectKotlinVersion = pluginOrderBugProject.getKotlinVersion()
+        assertTrue(projectKotlinVersion == "1.9.20")
         val dependencies = pluginOrderBugProject.dependencies()
         assertFalse(dependencies.output.contains("org.jetbrains.kotlin:kotlin-stdlib:{strictly $kotlinVersion}"),
             "Strict requirement for 'org.jetbrains.kotlin:kotlin-stdlib:{strictly $kotlinVersion}' was found in the project ${pluginOrderBugProject.projectName} dependencies, " +
-                    "while Kotlin version used in the project is ${pluginOrderBugProject.getKotlinVersion()}"
+                    "while Kotlin version used in the project is $projectKotlinVersion"
         )
     }
 }

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
@@ -76,8 +76,12 @@ internal fun BuildResult.mppNativeCheckAtomicfuInImplementation(targetName: Stri
 // It searches for:
 // "group": "org.jetbrains.kotlinx",
 // "module": "atomicfu-*", atomicfu or atomicfu-jvm
-internal fun GradleBuild.checkConsumableDependencies() {
-    publishToLocalRepository()
+internal fun GradleBuild.checkConsumableDependencies(runBuildTask: Boolean) {
+    if (runBuildTask) {
+        buildAndPublishToLocalRepository()
+    } else {
+        publishToLocalRepository()
+    }
     val moduleFile = getSampleProjectJarModuleFile(targetDir, projectName)
     val lines = moduleFile.readText().lines()
     var index = 0

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/checker/DependenciesChecker.kt
@@ -12,31 +12,34 @@ import kotlinx.atomicfu.gradle.plugin.test.framework.runner.dependencies
 private val commonAtomicfuDependency = "org.jetbrains.kotlinx:atomicfu:$atomicfuVersion"
 private val jvmAtomicfuDependency = "org.jetbrains.kotlinx:atomicfu-jvm:$atomicfuVersion"
 
-private fun GradleBuild.checkAtomicfuDependencyIsPresent(configurations: List<String>, atomicfuDependency: String) {
+internal fun GradleBuild.withDependencies(block: BuildResult.() -> Unit) {
     val dependencies = dependencies()
+    block(dependencies)
+}
+
+private fun BuildResult.checkAtomicfuDependencyIsPresent(configurations: List<String>, atomicfuDependency: String) {
     for (config in configurations) {
-        val configDependencies = dependencies.getDependenciesForConfig(config)
+        val configDependencies = getDependenciesForConfig(config)
         check(configDependencies.contains(atomicfuDependency)) { "Expected $atomicfuDependency in configuration $config, but it was not found." }
     }
 }
 
-private fun GradleBuild.checkAtomicfuDependencyIsAbsent(configurations: List<String>, atomicfuDependency: String) {
-    val dependencies = dependencies()
+private fun BuildResult.checkAtomicfuDependencyIsAbsent(configurations: List<String>, atomicfuDependency: String) {
     for (config in configurations) {
-        val configDependencies = dependencies.getDependenciesForConfig(config)
+        val configDependencies = getDependenciesForConfig(config)
         check(!configDependencies.contains(atomicfuDependency)) { "Dependency $atomicfuDependency should not be present in the configuration: $config" }
     }
 }
 
-internal fun GradleBuild.jvmCheckAtomicfuInCompileClasspath() {
+internal fun BuildResult.jvmCheckAtomicfuInCompileClasspath() {
     checkAtomicfuDependencyIsPresent(listOf("compileClasspath"), jvmAtomicfuDependency)
 }
 
-internal fun GradleBuild.mppCheckAtomicfuInCompileClasspath(targetName: String) {
+internal fun BuildResult.mppCheckAtomicfuInCompileClasspath(targetName: String) {
     checkAtomicfuDependencyIsPresent(listOf("${targetName}CompileClasspath"), commonAtomicfuDependency)
 }
 
-internal fun GradleBuild.mppCheckAtomicfuInRuntimeClasspath(targetName: String) {
+internal fun BuildResult.mppCheckAtomicfuInRuntimeClasspath(targetName: String) {
     checkAtomicfuDependencyIsPresent(listOf("${targetName}CompileClasspath"), commonAtomicfuDependency)
 }
 
@@ -50,20 +53,20 @@ internal fun GradleBuild.mppCheckAtomicfuInRuntimeClasspath(targetName: String) 
  * The functions below check that `org.jetbrains.kotlinx:atomicfu` dependency is not present in the runtime configurations.
  */
 
-internal fun GradleBuild.jvmCheckNoAtomicfuInRuntimeConfigs() {
+internal fun BuildResult.jvmCheckNoAtomicfuInRuntimeConfigs() {
     checkAtomicfuDependencyIsAbsent(listOf("runtimeClasspath", "apiElements", "runtimeElements"), jvmAtomicfuDependency)
 }
 
-internal fun GradleBuild.mppCheckNoAtomicfuInRuntimeConfigs(targetName: String) {
+internal fun BuildResult.mppCheckNoAtomicfuInRuntimeConfigs(targetName: String) {
     checkAtomicfuDependencyIsAbsent(listOf("${targetName}RuntimeClasspath", "${targetName}ApiElements", "${targetName}RuntimeElements"), commonAtomicfuDependency)
 }
 
-internal fun GradleBuild.mppCheckAtomicfuInApi(targetName: String) {
+internal fun BuildResult.mppCheckAtomicfuInApi(targetName: String) {
     checkAtomicfuDependencyIsPresent(listOf("${targetName}MainApi"), commonAtomicfuDependency)
 }
 
 // Checks Native target of an MPP project
-internal fun GradleBuild.mppNativeCheckAtomicfuInImplementation(targetName: String) {
+internal fun BuildResult.mppNativeCheckAtomicfuInImplementation(targetName: String) {
     checkAtomicfuDependencyIsPresent(listOf("${targetName}MainImplementation"), commonAtomicfuDependency)
 }
 

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
@@ -28,6 +28,11 @@ internal fun GradleBuild.publishToLocalRepository(): BuildResult =
         require(it.isSuccessful) { "${this.projectName}:publish task FAILED: ${it.output} " }
     }
 
+internal fun GradleBuild.buildAndPublishToLocalRepository(): BuildResult =
+    runGradle(listOf("clean", "build", "publish")).also {
+        require(it.isSuccessful) { "${this.projectName}:publish task FAILED: ${it.output} " }
+    }
+
 internal fun GradleBuild.getKotlinVersion(): String {
     val classpath = getProjectClasspath()
     val kpg = classpath.firstOrNull { it.startsWith("org.jetbrains.kotlin:kotlin-gradle-plugin") }


### PR DESCRIPTION
Speedup integration tests execution by:
- abstaining from running redundant commands;
- combining multiple commands into a single Gradle invocation, where possible;
- enable parallel tests suite execution;
- split the slowest suite (`MppProjectTest`) into a several suite to exploit parallel suite execution.

As a result, on Windows (which is the slowest platform w.r.t. tests execution), execution times improves by 15 minutes.