### PR TITLE
Enable stricter Gradle plugin validation

### DIFF
--- a/atomicfu-gradle-plugin/build.gradle.kts
+++ b/atomicfu-gradle-plugin/build.gradle.kts
@@ -56,3 +56,7 @@ gradlePlugin {
         }
     }
 }
+
+tasks.validatePlugins {
+    enableStricterValidation = true
+}


### PR DESCRIPTION
Enabling stricter validation means problems with configuration of the Gradle plugin can be caught earlier.

Unfortunately it's not enabled by default yet https://github.com/gradle/gradle/issues/22600