### PR TITLE
Fix deleting stale files in Gradle transform task

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -74,8 +74,8 @@ private fun Project.checkCompatibility(afuPluginVersion: String) {
         )
     }
     if (!kotlinVersion.atLeast(1, 9, 0)) {
-        // Since Kotlin 1.9.0 the logic of the Gradle plugin from the Kotlin repo (AtomicfuKotlinGradleSubplugin) 
-        // may be moved to the Gradle plugin in the library. The sources of the compiler plugin 
+        // Since Kotlin 1.9.0 the logic of the Gradle plugin from the Kotlin repo (AtomicfuKotlinGradleSubplugin)
+        // may be moved to the Gradle plugin in the library. The sources of the compiler plugin
         // are published as `kotlin-atomicfu-compiler-plugin-embeddable` since Kotlin 1.9.0 and may be accessed out of the Kotlin repo.
         error(
             "You are applying `kotlinx-atomicfu` plugin of version $afuPluginVersion. " +
@@ -487,6 +487,7 @@ abstract class AtomicFUTransformTask : ConventionTask() {
 
     @TaskAction
     fun transform() {
+        destinationDirectory.get().asFile.deleteRecursively()
         val cp = classPath.files.map { it.absolutePath }
         inputFiles.files.forEach { inputDir ->
             AtomicFUTransformer(cp, inputDir, destinationDirectory.get().asFile).let { t ->

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/BuildRunner.kt
@@ -7,6 +7,9 @@ package kotlinx.atomicfu.gradle.plugin.test.framework.runner
 import java.io.File
 import java.nio.file.Files
 
+/**
+ * @param[targetDir] The root Gradle project directory.
+ */
 internal class GradleBuild(val projectName: String, val targetDir: File) {
     var enableJvmIrTransformation = false
     var enableJsIrTransformation = false

--- a/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
+++ b/integration-testing/src/functionalTest/kotlin/kotlinx.atomicfu.gradle.plugin.test/framework/runner/Commands.kt
@@ -6,6 +6,11 @@ package kotlinx.atomicfu.gradle.plugin.test.framework.runner
 
 import kotlinx.atomicfu.gradle.plugin.test.framework.checker.getProjectClasspath
 
+internal fun GradleBuild.build(): BuildResult =
+    runGradle(listOf("build")).also {
+        require(it.isSuccessful) { "${this.projectName}:build task FAILED: ${it.output} " }
+    }
+
 internal fun GradleBuild.cleanAndBuild(): BuildResult =
     runGradle(listOf("clean", "build")).also {
         require(it.isSuccessful) { "${this.projectName}:build task FAILED: ${it.output} " }
@@ -13,8 +18,8 @@ internal fun GradleBuild.cleanAndBuild(): BuildResult =
 
 internal fun GradleBuild.cleanAndJar(): BuildResult = runGradle(listOf("clean", "jar"))
 
-internal fun GradleBuild.dependencies(): BuildResult = 
-    runGradle(listOf("dependencies")).also { 
+internal fun GradleBuild.dependencies(): BuildResult =
+    runGradle(listOf("dependencies")).also {
         require(it.isSuccessful) { "${this.projectName}:dependencies task FAILED: ${it.output} " }
     }
 


### PR DESCRIPTION
When source files are deleted Atomicfu would not delete the transformed files. Previously transformed files should be deleted whenever the transformer runs, so stale files do not linger.

Fix #547