### PR TITLE
Update `kotlin-for-gradle-plugin` to `2.2`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.2.0"
-kotlin-for-gradle-plugin = "2.1.0"
+kotlin-for-gradle-plugin = "2.2.0"
 kotlinx-binaryCompatibilityValidator = "0.17.0"
 asm = "9.8"
 slf4j = "1.8.0-alpha2"


### PR DESCRIPTION
This is required for 2.3 bootstrapping as bumping the version to 2.3 produces artifacts with metadata 2.3, and KGP brings compiler `2.0.21` which can't read it.

^KT-76136