### PR TITLE
Use Compilation.defaultSourceSet to declare dependencies

### DIFF
--- a/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
+++ b/atomicfu-gradle-plugin/src/main/kotlin/kotlinx/atomicfu/plugin/gradle/AtomicFUGradlePlugin.kt
@@ -205,7 +205,7 @@ private fun Project.addJsCompilerPluginRuntimeDependency() {
         withKotlinTargets { target ->
             if (needsJsIrTransformation(target.platformType)) {
                 target.compilations.forEach { kotlinCompilation ->
-                    kotlinCompilation.dependencies {
+                    kotlinCompilation.defaultSourceSet.dependencies {
                         if (getKotlinVersion().atLeast(1, 7, 10)) {
                             // since Kotlin 1.7.10 `kotlinx-atomicfu-runtime` is published and should be added directly
                             implementation("org.jetbrains.kotlin:kotlinx-atomicfu-runtime:${getKotlinPluginVersion()}")


### PR DESCRIPTION
Dependencies on KotlinCompilation level is being deprecated.
See KT-67290