### PR TITLE
Fix copy-pasted Gradle property name in getOverridingKotlinApiVersion KDoc

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinConfiguration.kt
+++ b/buildSrc/src/main/kotlin/KotlinConfiguration.kt
@@ -60,7 +60,7 @@ fun getOverridingKotlinLanguageVersion(project: Project): String? {
  * @return a Kotlin API version taken from:
  *
  * 1. the Kotlin community project Gradle plugin,
- * 2. or `kotlin_language_version` Gradle property (from command line or from `gradle.properties`),
+ * 2. or `kotlin_api_version` Gradle property (from command line or from `gradle.properties`),
  *
  * or null otherwise
  */


### PR DESCRIPTION
## Summary

Fixes a copy-paste error in the KDoc of `getOverridingKotlinApiVersion` in `buildSrc/src/main/kotlin/KotlinConfiguration.kt`.

The doc block was copied from `getOverridingKotlinLanguageVersion` directly above it, and the `@return` line was updated ("a Kotlin API version taken from") but the Gradle property name was not. It still documented `kotlin_language_version`, while the function actually reads `kotlin_api_version`:

```kotlin
fun getOverridingKotlinApiVersion(project: Project): String? {
    val providers = project.providers
    val apiVersion = providers.gradleProperty("community.project.kotlin.apiVersion")
        .orElse(providers.gradleProperty("kotlin_api_version"))   // <- documented as kotlin_language_version
```

Anyone following the doc would set the wrong Gradle property and see no effect.

One-line comment change; no functional changes.