### PR TITLE
Temporarily set `-Xallow-pre-17-runtime-jdk`

### DIFF
--- a/atomicfu/build.gradle.kts
+++ b/atomicfu/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -11,7 +12,11 @@ plugins {
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     jvmToolchain(8)
-    
+
+    compilerOptions {
+        freeCompilerArgs.add("-Xallow-pre-17-runtime-jdk")
+    }
+
     // Tier 1
     macosArm64()
     iosSimulatorArm64()

--- a/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
 //     Regular java modules need 'java-library' plugin for proper publication
     `java-library`
@@ -8,6 +10,10 @@ plugins {
 
 kotlin {
     jvmToolchain(8)
+
+    compilerOptions {
+        freeCompilerArgs.add("-Xallow-pre-17-runtime-jdk")
+    }
 }
 
 project.configureImplementationJarManifest("jar")


### PR DESCRIPTION
Bumping `jvmToolchain(11)` up to 17 still runs the compiler with JDK 11 taken from `JAVA_HOME`, which must be addressed separately.

Main PR to Kotlin: https://github.com/JetBrains/kotlin/pull/7833

^[KT-88174](https://youtrack.jetbrains.com/issue/KT-88174)
